### PR TITLE
[PR-7] feat: add company-wide WFH period management with automatic location fallback

### DIFF
--- a/01-task-1-craftsbite/craftsbite-backend/cmd/server/main.go
+++ b/01-task-1-craftsbite/craftsbite-backend/cmd/server/main.go
@@ -73,6 +73,7 @@ func main() {
 	historyRepo := repository.NewHistoryRepository(db)
 	teamRepo := repository.NewTeamRepository(db)
 	workLocationRepo := repository.NewWorkLocationRepository(db)
+	wfhPeriodRepo := repository.NewWFHPeriodRepository(db)
 
 	// Initialize services
 	authService := services.NewAuthService(userRepo, cfg)
@@ -81,7 +82,8 @@ func main() {
 	mealService := services.NewMealService(mealRepo, scheduleRepo, historyRepo, userRepo, teamRepo, participationResolver, cfg)
 	scheduleService := services.NewScheduleService(scheduleRepo)
 	headcountService := services.NewHeadcountService(userRepo, scheduleRepo, participationResolver)
-	workLocationService := services.NewWorkLocationService(workLocationRepo, userRepo, teamRepo)
+	workLocationService := services.NewWorkLocationService(workLocationRepo, userRepo, teamRepo, wfhPeriodRepo)
+	wfhPeriodService := services.NewWFHPeriodService(wfhPeriodRepo)
 
 	// Phase 4: Initialize advanced feature services
 	preferenceService := services.NewPreferenceService(userRepo, historyRepo)
@@ -98,6 +100,7 @@ func main() {
 	bulkOptOutHandler := handlers.NewBulkOptOutHandler(bulkOptOutService)
 	historyHandler := handlers.NewHistoryHandler(historyService)
 	workLocationHandler := handlers.NewWorkLocationHandler(workLocationService)
+	wfhPeriodHandler := handlers.NewWFHPeriodHandler(wfhPeriodService)
 
 	// Phase 4: Initialize cleanup job
 	// cleanupJob := jobs.NewCleanupJob(historyRepo, cfg.Cleanup.RetentionMonths)
@@ -131,6 +134,7 @@ func main() {
         BulkOptOut: bulkOptOutHandler,
         History:    historyHandler,
 		WorkLocation: workLocationHandler,
+		WFHPeriod:    wfhPeriodHandler,
     }, cfg)
 
 	// Create HTTP server

--- a/01-task-1-craftsbite/craftsbite-backend/internal/handlers/wfh_period_handler.go
+++ b/01-task-1-craftsbite/craftsbite-backend/internal/handlers/wfh_period_handler.go
@@ -1,0 +1,72 @@
+package handlers
+
+import (
+	"craftsbite-backend/internal/services"
+	"craftsbite-backend/internal/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+type WFHPeriodHandler struct {
+	svc services.WFHPeriodService
+}
+
+func NewWFHPeriodHandler(svc services.WFHPeriodService) *WFHPeriodHandler {
+	return &WFHPeriodHandler{svc: svc}
+}
+
+type createWFHPeriodRequest struct {
+	StartDate string  `json:"start_date" binding:"required"`
+	EndDate   string  `json:"end_date" binding:"required"`
+	Reason    *string `json:"reason"`
+}
+
+// POST /api/v1/wfh-periods
+func (h *WFHPeriodHandler) CreateWFHPeriod(c *gin.Context) {
+	adminID, exists := c.Get("user_id")
+	if !exists {
+		utils.ErrorResponse(c, 401, "UNAUTHORIZED", "User not authenticated")
+		return
+	}
+
+	var req createWFHPeriodRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.ErrorResponse(c, 400, "VALIDATION_ERROR", "Invalid request body: "+err.Error())
+		return
+	}
+
+	resp, err := h.svc.CreatePeriod(adminID.(string), req.StartDate, req.EndDate, req.Reason)
+	if err != nil {
+		utils.ErrorResponse(c, 400, "CREATE_WFH_PERIOD_ERROR", err.Error())
+		return
+	}
+
+	utils.SuccessResponse(c, 201, resp, "WFH period created successfully")
+}
+
+// GET /api/v1/wfh-periods
+func (h *WFHPeriodHandler) ListWFHPeriods(c *gin.Context) {
+	result, err := h.svc.ListPeriods()
+	if err != nil {
+		utils.ErrorResponse(c, 500, "LIST_WFH_PERIODS_ERROR", err.Error())
+		return
+	}
+
+	utils.SuccessResponse(c, 200, result, "WFH periods retrieved")
+}
+
+// DELETE /api/v1/wfh-periods/:id
+func (h *WFHPeriodHandler) DeleteWFHPeriod(c *gin.Context) {
+	id := c.Param("id")
+	if id == "" {
+		utils.ErrorResponse(c, 400, "VALIDATION_ERROR", "Period ID is required")
+		return
+	}
+
+	if err := h.svc.DeletePeriod(id); err != nil {
+		utils.ErrorResponse(c, 400, "DELETE_WFH_PERIOD_ERROR", err.Error())
+		return
+	}
+
+	utils.SuccessResponse(c, 200, nil, "WFH period deleted successfully")
+}

--- a/01-task-1-craftsbite/craftsbite-backend/internal/models/wfh_period.go
+++ b/01-task-1-craftsbite/craftsbite-backend/internal/models/wfh_period.go
@@ -1,0 +1,26 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// WFHPeriod represents a company-wide Work From Home period
+type WFHPeriod struct {
+	ID        uuid.UUID `gorm:"type:uuid;primary_key;default:gen_random_uuid()" json:"id"`
+	StartDate string    `gorm:"type:date;not null" json:"start_date"`
+	EndDate   string    `gorm:"type:date;not null" json:"end_date"`
+	Reason    *string   `gorm:"type:text" json:"reason,omitempty"`
+	CreatedBy uuid.UUID `gorm:"type:uuid;not null" json:"created_by"`
+	Active    bool      `gorm:"not null;default:true" json:"active"`
+	CreatedAt time.Time `gorm:"autoCreateTime" json:"created_at"`
+	UpdatedAt time.Time `gorm:"autoUpdateTime" json:"updated_at"`
+
+	// Relationships
+	Creator User `gorm:"foreignKey:CreatedBy" json:"creator,omitempty"`
+}
+
+func (WFHPeriod) TableName() string {
+	return "wfh_periods"
+}

--- a/01-task-1-craftsbite/craftsbite-backend/internal/repository/wfh_period_repository.go
+++ b/01-task-1-craftsbite/craftsbite-backend/internal/repository/wfh_period_repository.go
@@ -1,0 +1,82 @@
+package repository
+
+import (
+	"craftsbite-backend/internal/models"
+	"fmt"
+
+	"gorm.io/gorm"
+)
+
+// WFHPeriodRepository defines data-access for company-wide WFH periods
+type WFHPeriodRepository interface {
+	Create(period *models.WFHPeriod) error
+	FindByID(id string) (*models.WFHPeriod, error)
+	FindActiveByDate(date string) (*models.WFHPeriod, error)
+	FindAll() ([]models.WFHPeriod, error)
+	Delete(id string) error
+}
+
+type wfhPeriodRepository struct {
+	db *gorm.DB
+}
+
+func NewWFHPeriodRepository(db *gorm.DB) WFHPeriodRepository {
+	return &wfhPeriodRepository{db: db}
+}
+
+// Create inserts a new WFH period
+func (r *wfhPeriodRepository) Create(period *models.WFHPeriod) error {
+	if err := r.db.Create(period).Error; err != nil {
+		return fmt.Errorf("failed to create WFH period: %w", err)
+	}
+	return nil
+}
+
+// FindByID returns a single WFH period by its UUID
+func (r *wfhPeriodRepository) FindByID(id string) (*models.WFHPeriod, error) {
+	var period models.WFHPeriod
+	err := r.db.Preload("Creator").Where("id = ?", id).First(&period).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to find WFH period: %w", err)
+	}
+	return &period, nil
+}
+
+// FindActiveByDate returns the first active WFH period covering the given date, or nil
+func (r *wfhPeriodRepository) FindActiveByDate(date string) (*models.WFHPeriod, error) {
+	var period models.WFHPeriod
+	err := r.db.Where("active = ? AND start_date <= ? AND end_date >= ?", true, date, date).
+		First(&period).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to find active WFH period for date: %w", err)
+	}
+	return &period, nil
+}
+
+// FindAll returns all WFH periods ordered by start_date DESC
+func (r *wfhPeriodRepository) FindAll() ([]models.WFHPeriod, error) {
+	var periods []models.WFHPeriod
+	err := r.db.Preload("Creator").Order("start_date DESC").Find(&periods).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to list WFH periods: %w", err)
+	}
+	return periods, nil
+}
+
+// Delete hard-deletes a WFH period by ID
+func (r *wfhPeriodRepository) Delete(id string) error {
+	result := r.db.Delete(&models.WFHPeriod{}, "id = ?", id)
+	if result.Error != nil {
+		return fmt.Errorf("failed to delete WFH period: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("WFH period not found")
+	}
+	return nil
+}

--- a/01-task-1-craftsbite/craftsbite-backend/internal/routes/routes.go
+++ b/01-task-1-craftsbite/craftsbite-backend/internal/routes/routes.go
@@ -19,6 +19,7 @@ type Handlers struct {
     BulkOptOut  *handlers.BulkOptOutHandler
     History     *handlers.HistoryHandler
     WorkLocation *handlers.WorkLocationHandler
+    WFHPeriod    *handlers.WFHPeriodHandler
 }
 
 func RegisterRoutes(router *gin.Engine, h *Handlers, cfg *config.Config) {
@@ -34,6 +35,7 @@ func RegisterRoutes(router *gin.Engine, h *Handlers, cfg *config.Config) {
         registerHeadcountRoutes(v1, h, cfg)
         registerAdminRoutes(v1, h, cfg)
         registerWorkLocationRoutes(v1, h, cfg)
+        registerWFHPeriodRoutes(v1, h, cfg)
     }
 }
 
@@ -147,6 +149,17 @@ func registerWorkLocationRoutes(v1 *gin.RouterGroup, h *Handlers, cfg *config.Co
 
         wl.POST("/override", middleware.RequireRoles(models.RoleAdmin, models.RoleTeamLead), h.WorkLocation.SetWorkLocationFor)
         wl.GET("/list", middleware.RequireRoles(models.RoleAdmin, models.RoleTeamLead), h.WorkLocation.ListWorkLocationsByDate)
+    }
+}
+
+func registerWFHPeriodRoutes(v1 *gin.RouterGroup, h *Handlers, cfg *config.Config) {
+    periods := v1.Group("/wfh-periods")
+    periods.Use(middleware.AuthMiddleware(cfg.JWT.Secret))
+    periods.Use(middleware.RequireRoles(models.RoleAdmin, models.RoleLogistics))
+    {
+        periods.POST("", h.WFHPeriod.CreateWFHPeriod)
+        periods.GET("", h.WFHPeriod.ListWFHPeriods)
+        periods.DELETE("/:id", h.WFHPeriod.DeleteWFHPeriod)
     }
 }
 

--- a/01-task-1-craftsbite/craftsbite-backend/internal/services/wfh_period_service.go
+++ b/01-task-1-craftsbite/craftsbite-backend/internal/services/wfh_period_service.go
@@ -1,0 +1,116 @@
+package services
+
+import (
+	"craftsbite-backend/internal/models"
+	"craftsbite-backend/internal/repository"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// WFHPeriodService defines business logic for company-wide WFH periods
+type WFHPeriodService interface {
+	CreatePeriod(adminID, startDate, endDate string, reason *string) (*WFHPeriodResponse, error)
+	ListPeriods() ([]WFHPeriodResponse, error)
+	DeletePeriod(id string) error
+	IsDateInWFHPeriod(date string) (bool, error)
+}
+
+// WFHPeriodResponse is returned to clients
+type WFHPeriodResponse struct {
+	ID        string  `json:"id"`
+	StartDate string  `json:"start_date"`
+	EndDate   string  `json:"end_date"`
+	Reason    *string `json:"reason,omitempty"`
+	CreatedBy string  `json:"created_by"`
+	Active    bool    `json:"active"`
+	CreatedAt string  `json:"created_at"`
+}
+
+type wfhPeriodService struct {
+	repo repository.WFHPeriodRepository
+}
+
+func NewWFHPeriodService(repo repository.WFHPeriodRepository) WFHPeriodService {
+	return &wfhPeriodService{repo: repo}
+}
+
+// CreatePeriod creates a new company-wide WFH period
+func (s *wfhPeriodService) CreatePeriod(adminID, startDate, endDate string, reason *string) (*WFHPeriodResponse, error) {
+	// Validate dates
+	start, err := time.Parse("2006-01-02", startDate)
+	if err != nil {
+		return nil, fmt.Errorf("invalid start_date format, expected YYYY-MM-DD")
+	}
+	end, err := time.Parse("2006-01-02", endDate)
+	if err != nil {
+		return nil, fmt.Errorf("invalid end_date format, expected YYYY-MM-DD")
+	}
+	if end.Before(start) {
+		return nil, fmt.Errorf("end_date must not be before start_date")
+	}
+
+	adminUUID, err := uuid.Parse(adminID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid admin ID")
+	}
+
+	period := &models.WFHPeriod{
+		StartDate: startDate,
+		EndDate:   endDate,
+		Reason:    reason,
+		CreatedBy: adminUUID,
+		Active:    true,
+	}
+
+	if err := s.repo.Create(period); err != nil {
+		return nil, err
+	}
+
+	return &WFHPeriodResponse{
+		ID:        period.ID.String(),
+		StartDate: period.StartDate,
+		EndDate:   period.EndDate,
+		Reason:    period.Reason,
+		CreatedBy: period.CreatedBy.String(),
+		Active:    period.Active,
+		CreatedAt: period.CreatedAt.Format(time.RFC3339),
+	}, nil
+}
+
+// ListPeriods returns all WFH periods
+func (s *wfhPeriodService) ListPeriods() ([]WFHPeriodResponse, error) {
+	periods, err := s.repo.FindAll()
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]WFHPeriodResponse, 0, len(periods))
+	for _, p := range periods {
+		result = append(result, WFHPeriodResponse{
+			ID:        p.ID.String(),
+			StartDate: p.StartDate,
+			EndDate:   p.EndDate,
+			Reason:    p.Reason,
+			CreatedBy: p.CreatedBy.String(),
+			Active:    p.Active,
+			CreatedAt: p.CreatedAt.Format(time.RFC3339),
+		})
+	}
+	return result, nil
+}
+
+// DeletePeriod deletes a WFH period by ID
+func (s *wfhPeriodService) DeletePeriod(id string) error {
+	return s.repo.Delete(id)
+}
+
+// IsDateInWFHPeriod checks if a given date falls within any active WFH period
+func (s *wfhPeriodService) IsDateInWFHPeriod(date string) (bool, error) {
+	period, err := s.repo.FindActiveByDate(date)
+	if err != nil {
+		return false, err
+	}
+	return period != nil, nil
+}

--- a/01-task-1-craftsbite/craftsbite-backend/migrations/000010_create_wfh_periods_table.down.sql
+++ b/01-task-1-craftsbite/craftsbite-backend/migrations/000010_create_wfh_periods_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS wfh_periods;

--- a/01-task-1-craftsbite/craftsbite-backend/migrations/000010_create_wfh_periods_table.up.sql
+++ b/01-task-1-craftsbite/craftsbite-backend/migrations/000010_create_wfh_periods_table.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE wfh_periods (
+    id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    start_date  DATE        NOT NULL,
+    end_date    DATE        NOT NULL,
+    reason      TEXT,
+    created_by  UUID        NOT NULL REFERENCES users(id),
+    active      BOOLEAN     NOT NULL DEFAULT TRUE,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT chk_wfh_period_dates CHECK (end_date >= start_date)
+);

--- a/01-task-1-craftsbite/craftsbite-frontend/src/App.tsx
+++ b/01-task-1-craftsbite/craftsbite-frontend/src/App.tsx
@@ -11,6 +11,7 @@ import { OverridePanel } from "./pages/OverridePanel";
 import "./App.css";
 import { TeamParticipation } from "./pages/TeamParticipation";
 import { Schedule } from "./pages/Schedule";
+import { WFHPeriodPage } from "./pages/WFHPeriod";
 
 function App() {
   return (
@@ -79,6 +80,15 @@ function App() {
                 element={
                   <ProtectedRoute allowedRoles={["admin", "logistics"]}>
                     <Schedule />
+                  </ProtectedRoute>
+                }
+              />
+
+              <Route
+                path="/wfh-periods"
+                element={
+                  <ProtectedRoute allowedRoles={["admin", "logistics"]}>
+                    <WFHPeriodPage />
                   </ProtectedRoute>
                 }
               />

--- a/01-task-1-craftsbite/craftsbite-frontend/src/components/layout/Navbar.tsx
+++ b/01-task-1-craftsbite/craftsbite-frontend/src/components/layout/Navbar.tsx
@@ -24,7 +24,8 @@ export const Navbar: React.FC = () => {
         ...(user?.role === 'admin' || user?.role === 'logistics'
             ? [
                 { id: 'headcount', label: 'Headcount', icon: 'groups', href: '/headcount' },
-                { id: 'schedule', label: 'Schedule', icon: 'calendar_today', href: '/schedule' }
+                { id: 'schedule', label: 'Schedule', icon: 'calendar_today', href: '/schedule' },
+                { id: 'wfh-periods', label: 'WFH Periods', icon: 'date_range', href: '/wfh-periods' }
             ]
             : []),
         ...(user?.role === 'admin' || user?.role === 'team_lead'

--- a/01-task-1-craftsbite/craftsbite-frontend/src/components/modals/CreateWFHPeriodModal.tsx
+++ b/01-task-1-craftsbite/craftsbite-frontend/src/components/modals/CreateWFHPeriodModal.tsx
@@ -1,0 +1,173 @@
+import React, { useState, useEffect } from "react";
+import type { CreateWFHPeriodRequest } from "../../types/wfh-period.types";
+
+export interface CreateWFHPeriodModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (payload: CreateWFHPeriodRequest) => Promise<void>;
+}
+
+export const CreateWFHPeriodModal: React.FC<CreateWFHPeriodModalProps> = ({
+  isOpen,
+  onClose,
+  onSubmit,
+}) => {
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+  const [reason, setReason] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (isOpen) {
+      setStartDate("");
+      setEndDate("");
+      setReason("");
+      setError("");
+    }
+  }, [isOpen]);
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!startDate || !endDate) return;
+
+    if (endDate < startDate) {
+      setError("End date must be on or after start date.");
+      return;
+    }
+
+    const payload: CreateWFHPeriodRequest = {
+      start_date: startDate,
+      end_date: endDate,
+      ...(reason.trim() && { reason: reason.trim() }),
+    };
+
+    try {
+      setIsSubmitting(true);
+      setError("");
+      await onSubmit(payload);
+      onClose();
+    } catch (err: any) {
+      const errorMessage =
+        err?.error?.message ||
+        err?.message ||
+        "Failed to create WFH period. Please try again.";
+      setError(errorMessage);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/30 backdrop-blur-sm"
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <div className="w-full max-w-md bg-[#FFFDF5] rounded-[2rem] border border-[#e6dccf] shadow-[var(--shadow-clay-card)] p-8 flex flex-col gap-6">
+        <div className="flex items-center justify-between">
+          <h2 className="text-2xl font-black tracking-tight text-[var(--color-background-dark)]">
+            Create WFH Period
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="w-9 h-9 flex items-center justify-center rounded-xl text-[var(--color-text-sub)] hover:text-[var(--color-text-main)] hover:bg-[var(--color-background-light)] transition-all"
+          >
+            <span className="material-symbols-outlined text-[20px]">
+              close
+            </span>
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="flex flex-col gap-5">
+          {error && (
+            <div className="flex items-center gap-3 p-4 rounded-xl bg-red-50 border border-red-200">
+              <div>
+                <p className="text-sm font-semibold text-red-600">Error</p>
+                <p className="text-sm text-red-600 mt-1">{error}</p>
+              </div>
+            </div>
+          )}
+
+          <div className="flex flex-col gap-1.5">
+            <label className="text-[10px] font-bold uppercase tracking-widest text-[var(--color-text-sub)]">
+              Start Date
+            </label>
+            <input
+              type="date"
+              required
+              value={startDate}
+              onChange={(e) => setStartDate(e.target.value)}
+              className="w-full px-4 py-2.5 rounded-xl border border-[#e6dccf] bg-[var(--color-background-light)] text-[var(--color-text-main)] text-sm font-medium shadow-[var(--shadow-clay-button)] outline-none focus:border-[var(--color-primary)] transition-all"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label className="text-[10px] font-bold uppercase tracking-widest text-[var(--color-text-sub)]">
+              End Date
+            </label>
+            <input
+              type="date"
+              required
+              value={endDate}
+              min={startDate || undefined}
+              onChange={(e) => setEndDate(e.target.value)}
+              className="w-full px-4 py-2.5 rounded-xl border border-[#e6dccf] bg-[var(--color-background-light)] text-[var(--color-text-main)] text-sm font-medium shadow-[var(--shadow-clay-button)] outline-none focus:border-[var(--color-primary)] transition-all"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label className="text-[10px] font-bold uppercase tracking-widest text-[var(--color-text-sub)]">
+              Reason{" "}
+              <span className="normal-case tracking-normal font-normal opacity-60">
+                (optional)
+              </span>
+            </label>
+            <input
+              type="text"
+              placeholder="e.g. Office renovation, team retreat…"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              className="w-full px-4 py-2.5 rounded-xl border border-[#e6dccf] bg-[var(--color-background-light)] text-[var(--color-text-main)] text-sm shadow-[var(--shadow-clay-button)] outline-none focus:border-[var(--color-primary)] transition-all placeholder:text-[var(--color-text-sub)]/50"
+            />
+          </div>
+
+          <div className="border-t border-[#e6dccf]" />
+
+          <div className="flex items-center justify-end gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2.5 rounded-xl border border-[#e6dccf] bg-[var(--color-background-light)] text-[var(--color-text-sub)] text-sm font-semibold shadow-[var(--shadow-clay-button)] hover:text-[var(--color-text-main)] active:shadow-[var(--shadow-clay-button-active)] transition-all"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={!startDate || !endDate || isSubmitting}
+              className="px-5 py-2.5 rounded-xl bg-gradient-to-br from-[#fa8c47] to-[#e57a36] text-white text-sm font-bold shadow-[6px_6px_12px_#e6dccf,-6px_-6px_12px_#ffffff] hover:scale-[1.02] active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100 transition-all flex items-center gap-2"
+            >
+              {isSubmitting ? (
+                <>
+                  <span className="material-symbols-outlined text-[16px] animate-spin">
+                    progress_activity
+                  </span>{" "}
+                  Creating…
+                </>
+              ) : (
+                <>
+                  <span className="material-symbols-outlined text-[16px]">
+                    add
+                  </span>{" "}
+                  Create
+                </>
+              )}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};

--- a/01-task-1-craftsbite/craftsbite-frontend/src/components/modals/index.ts
+++ b/01-task-1-craftsbite/craftsbite-frontend/src/components/modals/index.ts
@@ -3,3 +3,5 @@ export type { MealModalProps } from './MealModal';
 
 export { MealOptOutModal } from './MealOptOutModal';
 export type { MealOptOutModalProps } from './MealOptOutModal';
+export { CreateWFHPeriodModal } from './CreateWFHPeriodModal';
+export type { CreateWFHPeriodModalProps } from './CreateWFHPeriodModal';

--- a/01-task-1-craftsbite/craftsbite-frontend/src/pages/WFHPeriod.tsx
+++ b/01-task-1-craftsbite/craftsbite-frontend/src/pages/WFHPeriod.tsx
@@ -1,0 +1,188 @@
+import React, { useState, useEffect } from "react";
+import { Header, Footer, Navbar, LoadingSpinner } from "../components";
+import { useAuth } from "../contexts/AuthContext";
+import * as wfhPeriodService from "../services/wfhPeriodService";
+import type { WFHPeriod, CreateWFHPeriodRequest } from "../types/wfh-period.types";
+import { CreateWFHPeriodModal } from "../components/modals/CreateWFHPeriodModal";
+import toast from "react-hot-toast";
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export const WFHPeriodPage: React.FC = () => {
+  const { user } = useAuth();
+
+  const [periods, setPeriods] = useState<WFHPeriod[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const fetchPeriods = async () => {
+    try {
+      setIsLoading(true);
+      const res = await wfhPeriodService.listWFHPeriods();
+      if (res.success && res.data) {
+        setPeriods(res.data);
+      } else {
+        setPeriods([]);
+      }
+    } catch (err: any) {
+      const msg =
+        err?.error?.message || "Failed to load WFH periods.";
+      toast.error(msg);
+      setPeriods([]);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchPeriods();
+  }, []);
+
+  const handleCreate = async (payload: CreateWFHPeriodRequest) => {
+    try {
+      await wfhPeriodService.createWFHPeriod(payload);
+      toast.success("WFH period created successfully!");
+      fetchPeriods();
+    } catch (err: any) {
+      const msg =
+        err?.error?.message || "Failed to create WFH period.";
+      toast.error(msg);
+      throw err;
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      setDeletingId(id);
+      await wfhPeriodService.deleteWFHPeriod(id);
+      toast.success("WFH period deleted successfully!");
+      setPeriods((prev) => prev.filter((p) => p.id !== id));
+    } catch (err: any) {
+      const msg =
+        err?.error?.message || "Failed to delete WFH period.";
+      toast.error(msg);
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  if (isLoading) {
+    return <LoadingSpinner message="Loading WFH periods…" />;
+  }
+
+  return (
+    <div className="font-display bg-[var(--color-background-light)] text-[var(--color-text-main)] min-h-screen flex flex-col overflow-x-hidden">
+      <Header userName={user?.name} userRole={user?.role} />
+      <Navbar />
+
+      <main className="flex-grow container mx-auto px-6 py-8 md:px-12 max-w-2xl flex flex-col">
+        <div className="flex flex-col md:flex-row md:items-end justify-between gap-6 mb-8">
+          <div>
+            <h2 className="text-4xl font-black text-left text-[var(--color-background-dark)] mb-2 tracking-tight">
+              WFH Periods
+            </h2>
+            <p className="text-lg text-[var(--color-text-sub)] font-medium">
+              Manage company-wide Work From Home periods
+            </p>
+          </div>
+
+          <button
+            onClick={() => setIsModalOpen(true)}
+            className="px-5 py-3 rounded-xl bg-gradient-to-br from-[#fa8c47] to-[#e57a36] text-white font-bold shadow-[6px_6px_12px_#e6dccf,-6px_-6px_12px_#ffffff] hover:scale-[1.02] active:scale-[0.98] transition-all flex items-center gap-2 text-sm self-start md:self-auto"
+          >
+            <span className="material-symbols-outlined text-[18px]">add</span>
+            Create WFH Period
+          </button>
+        </div>
+
+        {periods.length > 0 ? (
+          <div className="flex flex-col gap-4">
+            {periods.map((period) => (
+              <div
+                key={period.id}
+                className="bg-[#FFFDF5] rounded-[2rem] border border-[#e6dccf] p-6 shadow-[var(--shadow-clay-card)] flex flex-col md:flex-row md:items-center justify-between gap-4"
+              >
+                <div className="flex items-start gap-4">
+                  <div className="w-12 h-12 rounded-2xl flex items-center justify-center shadow-[var(--shadow-clay-button)] bg-white shrink-0">
+                    <span className="material-symbols-outlined text-[24px] text-[var(--color-primary)]">
+                      date_range
+                    </span>
+                  </div>
+                  <div>
+                    <h3 className="text-lg font-black tracking-tight text-[var(--color-background-dark)]">
+                      {formatDate(period.start_date)} — {formatDate(period.end_date)}
+                    </h3>
+                    {period.reason && (
+                      <p className="text-sm text-[var(--color-text-sub)] mt-0.5">
+                        {period.reason}
+                      </p>
+                    )}
+                    <div className="flex items-center gap-3 mt-2">
+                      <span
+                        className={`inline-flex items-center px-2.5 py-0.5 rounded-lg text-[10px] font-bold uppercase tracking-wider ${
+                          period.active
+                            ? "bg-green-50 text-green-600 border border-green-200"
+                            : "bg-gray-50 text-gray-500 border border-gray-200"
+                        }`}
+                      >
+                        {period.active ? "Active" : "Inactive"}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+
+                <button
+                  onClick={() => handleDelete(period.id)}
+                  disabled={deletingId === period.id}
+                  className="self-start md:self-center px-4 py-2 rounded-xl border border-red-200 bg-red-50 text-red-600 text-sm font-semibold hover:bg-red-100 active:shadow-[var(--shadow-clay-button-active)] transition-all flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {deletingId === period.id ? (
+                    <>
+                      <span className="material-symbols-outlined text-[16px] animate-spin">
+                        progress_activity
+                      </span>
+                      Deleting…
+                    </>
+                  ) : (
+                    <>
+                      <span className="material-symbols-outlined text-[16px]">
+                        delete
+                      </span>
+                      Delete
+                    </>
+                  )}
+                </button>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="bg-[#FFFDF5] border border-[#e6dccf] px-6 py-4 rounded-2xl text-sm text-[var(--color-text-sub)] flex items-center gap-3">
+            <span className="material-symbols-outlined text-[20px]">info</span>
+            No WFH periods found. Use the button above to create one.
+          </div>
+        )}
+      </main>
+
+      <Footer
+        links={[
+          { label: "Privacy", href: "#" },
+          { label: "Terms", href: "#" },
+          { label: "Support", href: "#" },
+        ]}
+      />
+
+      <CreateWFHPeriodModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        onSubmit={handleCreate}
+      />
+    </div>
+  );
+};

--- a/01-task-1-craftsbite/craftsbite-frontend/src/services/wfhPeriodService.ts
+++ b/01-task-1-craftsbite/craftsbite-frontend/src/services/wfhPeriodService.ts
@@ -1,0 +1,28 @@
+import api from "./api";
+import type { ApiResponse } from "../types";
+import type { WFHPeriod, CreateWFHPeriodRequest } from "../types/wfh-period.types";
+
+// GET /wfh-periods
+export async function listWFHPeriods(): Promise<ApiResponse<WFHPeriod[]>> {
+  const response = await api.get<ApiResponse<WFHPeriod[]>>("/wfh-periods");
+  return response.data;
+}
+
+// Create a new WFH period.
+export async function createWFHPeriod(
+  payload: CreateWFHPeriodRequest
+): Promise<ApiResponse<WFHPeriod>> {
+  const response = await api.post<ApiResponse<WFHPeriod>>(
+    "/wfh-periods",
+    payload
+  );
+  return response.data;
+}
+
+// Delete a WFH period by ID.
+export async function deleteWFHPeriod(
+  id: string
+): Promise<ApiResponse<null>> {
+  const response = await api.delete<ApiResponse<null>>(`/wfh-periods/${id}`);
+  return response.data;
+}

--- a/01-task-1-craftsbite/craftsbite-frontend/src/types/index.ts
+++ b/01-task-1-craftsbite/craftsbite-frontend/src/types/index.ts
@@ -8,3 +8,4 @@ export * from './api.types';
 export * from './team.types';
 export * from './schedule.types';
 export * from './work-location.types';
+export * from './wfh-period.types';

--- a/01-task-1-craftsbite/craftsbite-frontend/src/types/wfh-period.types.ts
+++ b/01-task-1-craftsbite/craftsbite-frontend/src/types/wfh-period.types.ts
@@ -1,0 +1,15 @@
+export interface WFHPeriod {
+  id: string;
+  start_date: string;
+  end_date: string;
+  reason?: string;
+  created_by: string;
+  active: boolean;
+  created_at: string;
+}
+
+export interface CreateWFHPeriodRequest {
+  start_date: string;
+  end_date: string;
+  reason?: string;
+}


### PR DESCRIPTION
Closes #13 

## Dependencies

- Depends on work location tracking PR (must be merged first — this feature integrates with `GetMyLocation`)

## What does this PR do?

Adds company-wide WFH period management. Admins/Logistics can declare a date range as a WFH period, and any employee without an explicit location set on those dates will automatically get `"wfh"` instead of `"not_set"`.

## Type of Change

- [x] New feature

## What was changed

**Backend (Go):**
- Migration `000010` creates `wfh_periods` table with `UNIQUE`-safe date range and a `CHECK (end_date >= start_date)` constraint
- New repo, service, handler wired end-to-end — purely additive, no existing logic broken
- `GetMyLocation` updated with a 3-tier priority: explicit user row → active WFH period → `"not_set"`. This is the only behavioral change to existing code
- `NewWorkLocationService` receives `wfhPeriodRepo` as a new parameter — update the call in `main.go` accordingly
- All 3 endpoints (`POST`, `GET`, `DELETE /wfh-periods`) are behind `RequireRoles(admin, logistics)` middleware

**Frontend (React/TS):**
- New `/wfh-periods` page: lists all periods with active/inactive badge and a delete button per row
- New `CreateWFHPeriodModal`: start date, end date, optional reason — same styling as `CreateScheduleModal`
- Route protected with `ProtectedRoute allowedRoles={["admin", "logistics"]}`
- New types in `wfh-period.types.ts` and service in `wfhPeriodService.ts`

## Changelog

- Feature: Admins and Logistics can now declare company-wide WFH periods with a date range and optional reason
- Feature: Employees without an explicit location set during a WFH period automatically show as WFH

## How to Test

1. Run migration `000010` and restart the server
2. `POST /api/v1/wfh-periods` with `start_date`, `end_date`, optional `reason` as admin → expect `201` with period object
3. As an employee with **no** `work_locations` row for a date inside the period, call `GET /api/v1/work-location?date=<date>` → expect `location: "wfh"`
4. As the same employee, explicitly set location to `"office"` for that date → call GET again → expect `location: "office"` (explicit entry wins)
5. `DELETE /api/v1/wfh-periods/:id` → expect `200`, period removed
6. As an employee, attempt `POST /api/v1/wfh-periods` → expect `403`
7. Try creating with `end_date < start_date` → expect `400 "end_date must not be before start_date"`

## How QA Should Test

**Affected workflows:**
- Employee home page (WorkLocationCard — location resolution may now return `"wfh"` automatically)
- Override Panel (work location override still takes priority over WFH period)
- New `/wfh-periods` page (admin/logistics only)

**Checks:**
1. Admin creates a WFH period for next week → employee checks their location for a date in that range with no explicit entry → badge shows WFH
2. Employee explicitly sets office for a date inside the WFH period → their location shows office, not WFH
3. Admin deletes the WFH period → employee's location for that date (with no explicit entry) reverts to `"not_set"`
4. Logistics user can access `/wfh-periods` and create/delete periods
5. Employee navigating to `/wfh-periods` is redirected away
6. Creating a period with end date before start date shows inline error in modal, does not submit

## Rollback Plan

- Revert this PR
- Run migration down: `DROP TABLE IF EXISTS wfh_periods`
- Revert `GetMyLocation` in `work_location_service.go` to remove the WFH period fallback check

## Checklist

- [x] My code follows the project style guidelines
- [x] Code passes linting and type checks
- [x ] All tests pass

## Note for Reviewer

- The only change to **existing** behavior is in `GetMyLocation` — it now has a middle fallback step. Worth reviewing that the priority order is correct and that errors from `wfhPeriodRepo.FindActiveByDate` are properly propagated and don't silently swallow failures
- `NewWorkLocationService` signature changed — make sure `main.go` is updated to pass `wfhPeriodRepo` or the build will fail