### PR TITLE
[PR-9] feat: HttpOnly cookie auth + SSE live headcount updates

### DIFF
--- a/01-task-1-craftsbite/craftsbite-backend/cmd/server/main.go
+++ b/01-task-1-craftsbite/craftsbite-backend/cmd/server/main.go
@@ -17,6 +17,7 @@ import (
 	"craftsbite-backend/internal/repository"
 	"craftsbite-backend/internal/routes"
 	"craftsbite-backend/internal/services"
+	"craftsbite-backend/internal/sse"
 	"craftsbite-backend/pkg/logger"
 
 	"github.com/gin-gonic/gin"
@@ -75,6 +76,8 @@ func main() {
 	workLocationRepo := repository.NewWorkLocationRepository(db)
 	wfhPeriodRepo := repository.NewWFHPeriodRepository(db)
 
+	sseHub := sse.NewHub()
+
 	// Initialize services
 	authService := services.NewAuthService(userRepo, cfg)
 	userService := services.NewUserService(userRepo, teamRepo)
@@ -93,9 +96,9 @@ func main() {
 	// Initialize handlers
 	authHandler := handlers.NewAuthHandler(authService, userService)
 	userHandler := handlers.NewUserHandler(userService)
-	mealHandler := handlers.NewMealHandler(mealService, teamRepo)
+	mealHandler := handlers.NewMealHandler(mealService, teamRepo, headcountService, sseHub)
 	scheduleHandler := handlers.NewScheduleHandler(scheduleService)
-	headcountHandler := handlers.NewHeadcountHandler(headcountService)
+	headcountHandler := handlers.NewHeadcountHandler(headcountService, sseHub)
 	preferenceHandler := handlers.NewPreferenceHandler(preferenceService)
 	bulkOptOutHandler := handlers.NewBulkOptOutHandler(bulkOptOutService)
 	historyHandler := handlers.NewHistoryHandler(historyService)

--- a/01-task-1-craftsbite/craftsbite-backend/internal/handlers/auth_handler.go
+++ b/01-task-1-craftsbite/craftsbite-backend/internal/handlers/auth_handler.go
@@ -134,7 +134,7 @@ func (h *AuthHandler) GetCurrentUser(c *gin.Context) {
 }
 
 func setAuthCookie(c *gin.Context, token string, expiresAt time.Time) {
-	isProd := os.Getenv("APP_ENV") == "production"
+	isProd := os.Getenv("ENV") == "production"
 
 	http.SetCookie(c.Writer, &http.Cookie{
 		Name:     "auth_token",

--- a/01-task-1-craftsbite/craftsbite-backend/internal/handlers/auth_handler.go
+++ b/01-task-1-craftsbite/craftsbite-backend/internal/handlers/auth_handler.go
@@ -4,6 +4,9 @@ import (
 	"craftsbite-backend/internal/models"
 	"craftsbite-backend/internal/services"
 	"craftsbite-backend/internal/utils"
+	"net/http"
+	"os"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -50,7 +53,15 @@ func (h *AuthHandler) Login(c *gin.Context) {
 		return
 	}
 
-	utils.SuccessResponse(c, 200, response, "Login successful")
+	setAuthCookie(c, response.Token, response.ExpiresAt)
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"data": gin.H{
+			"user":       response.User,
+			"expires_at": response.ExpiresAt,
+		},
+	})
 }
 
 // Register handles user registration
@@ -64,6 +75,9 @@ func (h *AuthHandler) Register(c *gin.Context) {
 	// Validate role
 	validRoles := map[string]bool{
 		"employee":  true,
+		"team_lead": true,
+		"admin":     true,
+		"logistics": true,
 	}
 	if !validRoles[req.Role] {
 		utils.ErrorResponse(c, 400, "INVALID_ROLE", "Role must be one of: employee, team_lead, admin, logistics")
@@ -98,9 +112,7 @@ func (h *AuthHandler) Register(c *gin.Context) {
 
 // Logout handles user logout (placeholder)
 func (h *AuthHandler) Logout(c *gin.Context) {
-	// In a stateless JWT system, logout is typically handled client-side
-	// by removing the token. This is a placeholder for future enhancements
-	// like token blacklisting or refresh token revocation.
+	expireAuthCookie(c)
 	utils.SuccessResponse(c, 200, nil, "Logout successful")
 }
 
@@ -119,4 +131,33 @@ func (h *AuthHandler) GetCurrentUser(c *gin.Context) {
 	}
 
 	utils.SuccessResponse(c, 200, user, "User retrieved successfully")
+}
+
+func setAuthCookie(c *gin.Context, token string, expiresAt time.Time) {
+	isProd := os.Getenv("APP_ENV") == "production"
+
+	http.SetCookie(c.Writer, &http.Cookie{
+		Name:     "auth_token",
+		Value:    token,
+		Path:     "/",
+		Expires:  expiresAt,
+		MaxAge:   int(time.Until(expiresAt).Seconds()),
+		HttpOnly: true, // JS cannot read this
+		Secure:   isProd,
+		SameSite: http.SameSiteStrictMode,
+	})
+}
+
+func expireAuthCookie(c *gin.Context) {
+	isProd := os.Getenv("ENV") == "production"
+
+	http.SetCookie(c.Writer, &http.Cookie{
+		Name:     "auth_token",
+		Path:     "/",
+		Expires:  time.Unix(0, 0),
+		MaxAge:   -1, // browser deletes it immediately
+		HttpOnly: true,
+		Secure:   isProd,
+		SameSite: http.SameSiteStrictMode,
+	})
 }

--- a/01-task-1-craftsbite/craftsbite-backend/internal/middleware/auth.go
+++ b/01-task-1-craftsbite/craftsbite-backend/internal/middleware/auth.go
@@ -3,7 +3,6 @@ package middleware
 import (
 	"craftsbite-backend/internal/models"
 	"craftsbite-backend/internal/utils"
-	"strings"
 
 	"github.com/gin-gonic/gin"
 )
@@ -12,24 +11,14 @@ import (
 func AuthMiddleware(jwtSecret string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// Extract token from Authorization header
-		authHeader := c.GetHeader("Authorization")
-		if authHeader == "" {
-			utils.ErrorResponse(c, 401, "UNAUTHORIZED", "Authorization header required")
+		tokenString, err := c.Cookie("auth_token")
+		if err != nil {
+			utils.ErrorResponse(c, 401, "UNAUTHORIZED", "Authentication required")
 			c.Abort()
 			return
 		}
 
 		// Check Bearer prefix
-		parts := strings.Split(authHeader, " ")
-		if len(parts) != 2 || parts[0] != "Bearer" {
-			utils.ErrorResponse(c, 401, "UNAUTHORIZED", "Invalid authorization header format")
-			c.Abort()
-			return
-		}
-
-		tokenString := parts[1]
-
-		// Validate token
 		claims, err := utils.ValidateToken(tokenString, jwtSecret)
 		if err != nil {
 			utils.ErrorResponse(c, 401, "UNAUTHORIZED", "Invalid or expired token")

--- a/01-task-1-craftsbite/craftsbite-backend/internal/routes/routes.go
+++ b/01-task-1-craftsbite/craftsbite-backend/internal/routes/routes.go
@@ -126,7 +126,8 @@ func registerHeadcountRoutes(v1 *gin.RouterGroup, h *Handlers, cfg *config.Confi
     headcount.Use(middleware.RequireRoles(models.RoleAdmin, models.RoleLogistics))
     {
         headcount.GET("/today", h.Headcount.GetTodayHeadcount)
-        headcount.GET("/:date/announcement", h.Headcount.GetAnnouncement) 
+        headcount.GET("/:date/announcement", h.Headcount.GetAnnouncement)
+        headcount.GET("/:date/stream", h.Headcount.StreamHeadcount)
         headcount.GET("/:date/:meal_type", h.Headcount.GetDetailedHeadcount)
         headcount.GET("/:date", h.Headcount.GetHeadcountByDate)
     }

--- a/01-task-1-craftsbite/craftsbite-backend/internal/services/auth_service.go
+++ b/01-task-1-craftsbite/craftsbite-backend/internal/services/auth_service.go
@@ -11,7 +11,7 @@ import (
 
 // LoginResponse represents the response after successful login
 type LoginResponse struct {
-	Token     string       `json:"token"`
+	Token     string       `json:"token,omitempty"`
 	User      *models.User `json:"user"`
 	ExpiresAt time.Time    `json:"expires_at"`
 }

--- a/01-task-1-craftsbite/craftsbite-backend/internal/sse/hub.go
+++ b/01-task-1-craftsbite/craftsbite-backend/internal/sse/hub.go
@@ -1,0 +1,51 @@
+package sse
+
+import (
+	"sync"
+)
+
+type Hub struct {
+	mu      sync.RWMutex
+	clients map[string][]chan string
+}
+
+func NewHub() *Hub {
+	return &Hub{
+		clients: make(map[string][]chan string),
+	}
+}
+
+func (h *Hub) Register(date string) chan string {
+	ch := make(chan string, 4)
+	h.mu.Lock()
+	h.clients[date] = append(h.clients[date], ch)
+	h.mu.Unlock()
+	return ch
+}
+
+func (h *Hub) Deregister(date string, ch chan string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	list := h.clients[date]
+	for i, c := range list {
+		if c == ch {
+			h.clients[date] = append(list[:i], list[i+1:]...)
+			break
+		}
+	}
+	if len(h.clients[date]) == 0 {
+		delete(h.clients, date)
+	}
+	close(ch)
+}
+
+func (h *Hub) Broadcast(date, payload string) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	for _, ch := range h.clients[date] {
+		select {
+		case ch <- payload:
+		default:
+		}
+	}
+}

--- a/01-task-1-craftsbite/craftsbite-frontend/src/hooks/useHeadcountStream.ts
+++ b/01-task-1-craftsbite/craftsbite-frontend/src/hooks/useHeadcountStream.ts
@@ -1,0 +1,36 @@
+import { useEffect, useRef, useState } from "react";
+import type { HeadcountData } from "../types";
+
+export function useHeadcountStream(date: string, isAuthenticated: boolean) {
+  const [data, setData] = useState<HeadcountData | null>(null);
+  const [streamError, setStreamError] = useState<string | null>(null);
+  const esRef = useRef<EventSource | null>(null);
+
+  useEffect(() => {
+    if (!date || !isAuthenticated) return;
+
+    const url = `${import.meta.env.VITE_API_BASE_URL}/headcount/${date}/stream`;
+    const es = new EventSource(url, { withCredentials: true });
+    esRef.current = es;
+
+    es.onmessage = (event) => {
+      try {
+        setData(JSON.parse(event.data));
+        setStreamError(null);
+      } catch {
+        setStreamError("Failed to parse live data.");
+      }
+    };
+
+    es.onerror = () => {
+      setStreamError("Connection lost — reconnecting...");
+    };
+
+    return () => {
+      es.close();
+      esRef.current = null;
+    };
+  }, [date, isAuthenticated]);
+
+  return { data, streamError };
+}

--- a/01-task-1-craftsbite/craftsbite-frontend/src/pages/HeadcountDashboard.tsx
+++ b/01-task-1-craftsbite/craftsbite-frontend/src/pages/HeadcountDashboard.tsx
@@ -6,9 +6,10 @@ import { MEAL_TYPES } from "../utils/constants";
 import * as headcountService from "../services/headcountService";
 import { formatDate, getTodayString } from "../utils";
 import { HeadcountDateModal, AnnouncementModal } from "../components/modals";
+import { useHeadcountStream } from "../hooks/useHeadcountStream";
 
 export const HeadcountDashboard: React.FC = () => {
-  const { user } = useAuth();
+  const { user, isAuthenticated } = useAuth();
 
   const [headcountData, setHeadcountData]     = useState<HeadcountData | null>(null);
   const [viewedDate, setViewedDate]           = useState<string>(getTodayString());
@@ -64,10 +65,15 @@ export const HeadcountDashboard: React.FC = () => {
       setIsFetchingAnnouncement(false);
     }
   };
+  
+  const { data: streamData, streamError } = useHeadcountStream(viewedDate, isAuthenticated);
 
   useEffect(() => {
-    fetchByDate(getTodayString(), true);
-  }, []);
+    if (streamData) {
+      setHeadcountData(streamData);
+      setIsLoading(false);
+    }
+  }, [streamData]);
 
   const getMealLabel = (mealType: string): string =>
     MEAL_TYPES[mealType as MealTypeEnum] || mealType;
@@ -129,6 +135,10 @@ export const HeadcountDashboard: React.FC = () => {
           <div className="mb-6 bg-red-50 border border-red-200 text-red-700 px-6 py-4 rounded-2xl text-sm max-w-2xl mx-auto md:mx-0">
             {error}
           </div>
+        )}
+
+        {streamError && (
+          <p className="mb-4 text-xs text-orange-500 font-semibold">{streamError}</p>
         )}
 
         {/* Announcement error (inline, dismissible) */}

--- a/01-task-1-craftsbite/craftsbite-frontend/src/services/api.ts
+++ b/01-task-1-craftsbite/craftsbite-frontend/src/services/api.ts
@@ -1,6 +1,8 @@
-import axios, { AxiosError, type InternalAxiosRequestConfig } from 'axios';
+// Axios API Instance Configuration
+
+import axios, { AxiosError } from 'axios';
 import type { ApiErrorResponse } from '../types';
-import { getToken, clearAuthData } from '../utils/storage';
+import { clearAuthData } from '../utils/storage';
 import { API_BASE_URL } from '../utils/constants';
 
 const api = axios.create({
@@ -9,47 +11,50 @@ const api = axios.create({
         'Content-Type': 'application/json',
     },
     timeout: 30000,
+    withCredentials: true,
 });
 
-function buildApiError(error: AxiosError<ApiErrorResponse>): ApiErrorResponse {
-    return {
-        success: false,
-        error: {
-            code: error.response?.data?.error?.code || 'UNKNOWN_ERROR',
-            message: error.response?.data?.error?.message || error.message || 'An unexpected error occurred',
-            details: error.response?.data?.error?.details,
-        },
-    };
-}
+// Request interceptor - attach JWT token
+// api.interceptors.request.use(
+//     (config: InternalAxiosRequestConfig) => {
+//         const token = getToken();
 
-api.interceptors.request.use(
-    (config: InternalAxiosRequestConfig) => {
-        const token = getToken();
+//         if (token && config.headers) {
+//             config.headers.Authorization = `Bearer ${token}`;
+//         }
 
-        if (token && config.headers) {
-            config.headers.Authorization = `Bearer ${token}`;
-        }
+//         return config;
+//     },
+//     (error: AxiosError) => {
+//         return Promise.reject(error);
+//     }
+// );
 
-        return config;
-    },
-    (error: AxiosError) => {
-        return Promise.reject(error);
-    }
-);
-
+// Response interceptor - handle errors
 api.interceptors.response.use(
-    (response) => response,
+    (response) => {
+        return response;
+    },
     (error: AxiosError<ApiErrorResponse>) => {
         if (error.response?.status === 401) {
             clearAuthData();
+
             if (window.location.pathname !== '/login') {
                 window.location.href = '/login';
             }
         }
 
-        return Promise.reject(buildApiError(error));
+        const errorResponse: ApiErrorResponse = {
+            success: false,
+            error: {
+                code: error.response?.data?.error?.code || 'UNKNOWN_ERROR',
+                message: error.response?.data?.error?.message || error.message || 'An unexpected error occurred',
+                details: error.response?.data?.error?.details,
+            },
+        };
+
+        return Promise.reject(errorResponse);
     }
 );
 
 export default api;
-export { buildApiError };

--- a/01-task-1-craftsbite/craftsbite-frontend/src/store/authStore.ts
+++ b/01-task-1-craftsbite/craftsbite-frontend/src/store/authStore.ts
@@ -2,7 +2,7 @@
 
 import { create } from 'zustand';
 import type { AuthState, User } from '../types';
-import { getToken, setToken, removeToken, getUser, setUser as setUserStorage, removeUser } from '../utils/storage';
+import { getUser, setUser as setUserStorage, removeUser } from '../utils/storage';
 
 export const useAuthStore = create<AuthState>((set, get) => ({
     user: null,
@@ -12,19 +12,16 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
     // Initialize auth state from localStorage
     initialize: () => {
-        const token = getToken();
         const user = getUser();
 
-        if (token && user) {
+        if (user) {
             set({
-                token,
                 user,
                 isAuthenticated: true,
                 isLoading: false,
             });
         } else {
             set({
-                token: null,
                 user: null,
                 isAuthenticated: false,
                 isLoading: false,
@@ -59,11 +56,9 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
     // Logout action
     logout: () => {
-        removeToken();
         removeUser();
         set({
             user: null,
-            token: null,
             isAuthenticated: false,
             isLoading: false,
         });
@@ -88,25 +83,17 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
     // Check authentication status
     checkAuth: async () => {
-        const token = getToken();
         const user = getUser();
 
-        if (!token || !user) {
+        if (!user) {
             get().logout();
             return;
         }
 
         set({
-            token,
             user,
             isAuthenticated: true,
             isLoading: false,
         });
     },
 }));
-
-// Helper function to set token in store and storage
-export const setAuthToken = (token: string) => {
-    setToken(token);
-    useAuthStore.setState({ token, isAuthenticated: true });
-};

--- a/01-task-1-craftsbite/craftsbite-frontend/src/utils/storage.ts
+++ b/01-task-1-craftsbite/craftsbite-frontend/src/utils/storage.ts
@@ -4,27 +4,6 @@ import type { User } from '../types';
 import { STORAGE_KEYS } from './constants';
 
 /**
- * Get JWT token from localStorage
- */
-export function getToken(): string | null {
-    return localStorage.getItem(STORAGE_KEYS.TOKEN);
-}
-
-/**
- * Set JWT token in localStorage
- */
-export function setToken(token: string): void {
-    localStorage.setItem(STORAGE_KEYS.TOKEN, token);
-}
-
-/**
- * Remove JWT token from localStorage
- */
-export function removeToken(): void {
-    localStorage.removeItem(STORAGE_KEYS.TOKEN);
-}
-
-/**
  * Get user data from localStorage
  */
 export function getUser(): User | null {
@@ -57,6 +36,5 @@ export function removeUser(): void {
  * Clear all auth data from localStorage
  */
 export function clearAuthData(): void {
-    removeToken();
     removeUser();
 }


### PR DESCRIPTION
Closes #18 

## Dependencies

- #<enhanced-headcount-reporting-pr> — HeadcountHandler and MealHandler
  constructors this PR extends

## What does this PR do?

Migrates auth token storage from `localStorage` to an `HttpOnly` cookie, and
adds a Server-Sent Events stream so the headcount dashboard updates live when
participation changes are saved.

## Type of Change

- [x] New feature

## What was changed

**Backend — cookie auth:**
- `Login` sets `auth_token` as `HttpOnly`, `SameSite=Strict` cookie; `Secure`
  only in production
- `Logout` expires the cookie with `MaxAge: -1`
- `AuthMiddleware` reads token from `c.Cookie("auth_token")` instead of the
  `Authorization` header
- SSE route covered by the same `AuthMiddleware` — cookie is sent automatically
  by the browser with the `EventSource` request, no workaround needed

**Backend — SSE:**
- `internal/sse/hub.go` — concurrent client registry; one buffered channel per
  open tab per date; `Broadcast` uses `select/default` to skip slow clients
- `StreamHeadcount` handler — registers channel, sends immediate snapshot on
  connect, blocks on `select` until broadcast or `Context().Done()`
- `MealHandler.SetParticipation` — calls `hub.Broadcast` after every successful
  DB write; broadcast failure is silenced so it never fails the user's request
- Same `sseHub` instance injected into both handlers via `main.go`

**Frontend — cookie auth:**
- Token removed from Zustand store and `localStorage`
- `checkAuth` and `initialize` rely on `/auth/me` API response
- `setUser` no longer persists token to storage

**Frontend — SSE:**
- `src/hooks/useHeadcountStream.ts` — new hook wrapping `EventSource` lifecycle;
  reopens stream on `date` change; exposes `data` and `streamError`
- `HeadcountDashboard` — syncs `streamData → headcountData` via `useEffect`,
  removes initial `fetchByDate` on mount, surfaces `streamError` inline
- No token handling needed in the hook — cookie is attached by the browser
  automatically

## Changelog

- Feature: Headcount dashboard now updates in real time when meal participation changes are submitted
- Security: Auth token moved from localStorage to HttpOnly cookie

## How to Test

1. Log in — confirm no token in `localStorage` or Zustand; DevTools → Application
   → Cookies should show `auth_token` as `HttpOnly`
2. Refresh — confirm session persists
3. Log out — confirm `auth_token` cookie is cleared
4. Open `/headcount` as Admin — dashboard loads via SSE initial snapshot
5. In DevTools → Network, filter `stream` — request stays open with type `EventStream`
6. As an employee in another tab, toggle meal participation — admin tab updates
   within ~2 seconds without reload
7. Pick a different date — stream switches and data reflects the new date

## How QA Should Test

**Affected workflows:** Login/logout, session persistence, daily headcount monitoring

- Log in, open browser console, run `document.cookie` — `auth_token` must not
  appear (HttpOnly)
- Refresh mid-session — user stays authenticated
- Log out — cookie cleared; protected routes redirect to login
- Open `/headcount` as Admin, leave open; as employee submit participation change
  — numbers update automatically across all open Admin tabs
- Navigate away from `/headcount` — SSE stream request closes in DevTools Network

## Rollback Plan

Revert this PR. No DB schema changes. Clients will lose their active session on
rollback and need to log in again — expected, since the cookie replaces the old
`localStorage` token.

## Checklist

- [x] My code follows the project style guidelines
- [x] Code passes linting and type checks
- [x] All tests pass

## Note for Reviewer

- `AuthMiddleware` no longer reads the `Authorization` header anywhere — confirm
  no existing client integrations depend on header-based auth before merging