### PR TITLE
[PR-12] feat: feat: implement event_day status and add calender view for schedule page

### DIFF
--- a/01-task-1-craftsbite/craftsbite-backend/internal/models/enums.go
+++ b/01-task-1-craftsbite/craftsbite-backend/internal/models/enums.go
@@ -33,12 +33,14 @@ const (
 	DayStatusOfficeClosed DayStatus = "office_closed"
 	DayStatusGovtHoliday  DayStatus = "govt_holiday"
 	DayStatusCelebration  DayStatus = "celebration"
+	DayStatusWeekend      DayStatus = "weekend"
+    DayStatusEventDay     DayStatus = "event_day"
 )
 
 // IsValid checks if the day status is valid
 func (d DayStatus) IsValid() bool {
 	switch d {
-	case DayStatusNormal, DayStatusOfficeClosed, DayStatusGovtHoliday, DayStatusCelebration:
+	case DayStatusNormal, DayStatusOfficeClosed, DayStatusGovtHoliday, DayStatusCelebration, DayStatusWeekend, DayStatusEventDay:
 		return true
 	}
 	return false

--- a/01-task-1-craftsbite/craftsbite-frontend/src/components/cards/ScheduleCalender.tsx
+++ b/01-task-1-craftsbite/craftsbite-frontend/src/components/cards/ScheduleCalender.tsx
@@ -1,0 +1,177 @@
+import React from "react";
+import {
+    format,
+    startOfMonth,
+    endOfMonth,
+    startOfWeek,
+    endOfWeek,
+    addDays,
+    isSameMonth,
+    isToday,
+    isWeekend,
+} from "date-fns";
+import { STATUS_COLORS_FOR_SCHEDULE, type ScheduleEntry } from "../../types/schedule.types";
+
+
+const LEGEND = [
+    { color: "bg-emerald-400", label: "Normal" },
+    { color: "bg-red-700", label: "Office Closed" },
+    { color: "bg-sky-400", label: "Govt Holiday" },
+    { color: "bg-violet-400", label: "Celebration" },
+    { color: "bg-orange-400", label: "Event Day" },
+];
+
+const DAY_HEADERS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+export interface ScheduleCalendarProps {
+    currentMonth: Date;
+    scheduleMap: Record<string, ScheduleEntry>;
+    selectedDate: string;
+    onSelectDate: (date: string) => void;
+    onPrevMonth: () => void;
+    onNextMonth: () => void;
+}
+
+export const ScheduleCalendar: React.FC<ScheduleCalendarProps> = ({
+    currentMonth,
+    scheduleMap,
+    selectedDate,
+    onSelectDate,
+    onPrevMonth,
+    onNextMonth,
+}) => {
+    const monthStart = startOfMonth(currentMonth);
+    const monthEnd = endOfMonth(currentMonth);
+    const gridStart = startOfWeek(monthStart, { weekStartsOn: 1 });
+    const gridEnd = endOfWeek(monthEnd, { weekStartsOn: 1 });
+
+    const days: Date[] = [];
+    let cur = gridStart;
+    while (cur <= gridEnd) {
+        days.push(cur);
+        cur = addDays(cur, 1);
+    }
+
+    return (
+        <div className="bg-[#FFFDF5] rounded-[2rem] border border-[#e6dccf] p-6 shadow-[var(--shadow-clay-card)]">
+            {/* Month navigation */}
+            <div className="flex items-center justify-between mb-5">
+                <button
+                    onClick={onPrevMonth}
+                    className="w-9 h-9 rounded-xl flex items-center justify-center bg-[var(--color-background-light)] shadow-[var(--shadow-clay-button)] hover:text-[var(--color-primary)] active:shadow-[var(--shadow-clay-button-active)] transition-all"
+                >
+                    <span className="material-symbols-outlined text-[20px]">
+                        chevron_left
+                    </span>
+                </button>
+
+                <h3 className="text-xl font-black text-[var(--color-background-dark)] tracking-tight">
+                    {format(currentMonth, "MMMM yyyy")}
+                </h3>
+
+                <button
+                    onClick={onNextMonth}
+                    className="w-9 h-9 rounded-xl flex items-center justify-center bg-[var(--color-background-light)] shadow-[var(--shadow-clay-button)] hover:text-[var(--color-primary)] active:shadow-[var(--shadow-clay-button-active)] transition-all"
+                >
+                    <span className="material-symbols-outlined text-[20px]">
+                        chevron_right
+                    </span>
+                </button>
+            </div>
+
+            {/* Day-of-week headers */}
+            <div className="grid grid-cols-7 mb-2">
+                {DAY_HEADERS.map((d) => (
+                    <div
+                        key={d}
+                        className="text-center text-[10px] font-bold uppercase tracking-widest text-[var(--color-text-sub)] py-1"
+                    >
+                        {d}
+                    </div>
+                ))}
+            </div>
+
+            {/* Calendar grid */}
+            <div className="grid grid-cols-7 gap-1">
+                {days.map((day) => {
+                    const key = format(day, "yyyy-MM-dd");
+                    const entry = scheduleMap[key];
+                    const inMonth = isSameMonth(day, currentMonth);
+                    const todayDay = isToday(day);
+                    const selected = key === selectedDate;
+                    const weekend = isWeekend(day);
+                    const status = entry?.day_status;
+
+                    return (
+                        <button
+                            key={key}
+                            onClick={() => inMonth && onSelectDate(key)}
+                            disabled={!inMonth}
+                            className={[
+                                "relative flex flex-col items-center justify-start pt-1.5 pb-2 rounded-xl transition-all min-h-[52px]",
+                                inMonth
+                                    ? "cursor-pointer hover:bg-[#f5ede0]"
+                                    : "opacity-0 pointer-events-none",
+                                selected
+                                    ? "bg-gradient-to-br from-[#fa8c47] to-[#e57a36] shadow-[var(--shadow-clay-button)] text-white"
+                                    : weekend && inMonth
+                                      ? "bg-[#f5f0e8]"
+                                      : "",
+                            ]
+                                .filter(Boolean)
+                                .join(" ")}
+                        >
+                            <span
+                                className={[
+                                    "text-sm font-bold leading-none",
+                                    !inMonth
+                                        ? "text-transparent"
+                                        : selected
+                                          ? "text-white"
+                                          : todayDay
+                                            ? "text-[var(--color-primary)]"
+                                            : weekend
+                                              ? "text-[var(--color-text-sub)]"
+                                              : "text-[var(--color-background-dark)]",
+                                ].join(" ")}
+                            >
+                                {format(day, "d")}
+                            </span>
+
+                            {/* Today dot */}
+                            {todayDay && !selected && (
+                                <span className="absolute top-1 right-1 w-1.5 h-1.5 rounded-full bg-[var(--color-primary)]" />
+                            )}
+
+                            {/* Schedule dot */}
+                            {entry && inMonth && (
+                                <span
+                                    className={[
+                                        "mt-1 w-1.5 h-1.5 rounded-full",
+                                        selected
+                                            ? "bg-white"
+                                            : (STATUS_COLORS_FOR_SCHEDULE[status ?? "normal"] ??
+                                              "bg-gray-400"),
+                                    ].join(" ")}
+                                />
+                            )}
+                        </button>
+                    );
+                })}
+            </div>
+
+            {/* Legend */}
+            <div className="mt-4 pt-4 border-t border-[#e6dccf] flex flex-wrap gap-3">
+                {LEGEND.map(({ color, label }) => (
+                    <span
+                        key={label}
+                        className="flex items-center gap-1.5 text-[11px] font-medium text-[var(--color-text-sub)]"
+                    >
+                        <span className={`w-2 h-2 rounded-full ${color}`} />
+                        {label}
+                    </span>
+                ))}
+            </div>
+        </div>
+    );
+};

--- a/01-task-1-craftsbite/craftsbite-frontend/src/components/cards/index.ts
+++ b/01-task-1-craftsbite/craftsbite-frontend/src/components/cards/index.ts
@@ -11,3 +11,6 @@ export { AccentBorderCard } from './AccentBorderCard';
 export type { AccentBorderCardProps } from './AccentBorderCard';
 
 export { WorkLocationCard } from './WorkLocationCard';
+
+export { ScheduleCalendar } from './ScheduleCalender';
+export type { ScheduleCalendarProps } from './ScheduleCalender';

--- a/01-task-1-craftsbite/craftsbite-frontend/src/pages/Schedule.tsx
+++ b/01-task-1-craftsbite/craftsbite-frontend/src/pages/Schedule.tsx
@@ -1,55 +1,72 @@
-import React, { useState, useEffect } from "react";
-import { format, isWeekend } from "date-fns";
-import { Header, Footer, Navbar, LoadingSpinner } from "../components";
+import React, { useState, useEffect, useCallback } from "react";
+import {
+    format,
+    startOfMonth,
+    endOfMonth,
+    addMonths,
+    subMonths,
+    isWeekend,
+} from "date-fns";
+import { Header, Footer, Navbar, LoadingSpinner, ScheduleCalendar } from "../components";
 import { useAuth } from "../contexts/AuthContext";
 import * as scheduleService from "../services/scheduleService";
-import type { DayStatus } from "../types";
 import toast from "react-hot-toast";
 import type {
     CreateScheduleRequest,
     ScheduleEntry,
 } from "../types/schedule.types";
 import { CreateScheduleModal } from "../components/modals/CreateScheduleModal";
-import { STATUS_CONFIG, MEAL_LABELS } from "../types/schedule.types";
+import { STATUS_CONFIG, MEAL_LABELS, STATUS_COLORS_FOR_SCHEDULE } from "../types/schedule.types";
+
 
 export const Schedule: React.FC = () => {
     const { user } = useAuth();
     const today = new Date();
-    const todayKey = format(today, "yyyy-MM-dd");
-    const isWeekendDay = isWeekend(today);
 
-    const [schedule, setSchedule] = useState<ScheduleEntry | null>(null);
+    const [currentMonth, setCurrentMonth] = useState(
+        startOfMonth(today),
+    );
+    const [scheduleMap, setScheduleMap] = useState<
+        Record<string, ScheduleEntry>
+    >({});
     const [isLoading, setIsLoading] = useState(true);
     const [isModalOpen, setIsModalOpen] = useState(false);
+    const [selectedDate, setSelectedDate] = useState<string>(
+        format(today, "yyyy-MM-dd"),
+    );
 
-    const fetchTodaySchedule = async () => {
+    const fetchMonthSchedules = useCallback(async (monthStart: Date) => {
         try {
             setIsLoading(true);
-            const response = await scheduleService.getScheduleByDate(todayKey);
-            if (response.success && response.data) {
-                setSchedule(response.data);
+            const start = format(monthStart, "yyyy-MM-dd");
+            const end = format(endOfMonth(monthStart), "yyyy-MM-dd");
+            const response = await scheduleService.getScheduleRange(start, end);
+            if (response.success && Array.isArray(response.data)) {
+                const map: Record<string, ScheduleEntry> = {};
+                for (const entry of response.data) {
+                    const key = format(new Date(entry.date), "yyyy-MM-dd");
+                    map[key] = entry;
+                }
+                setScheduleMap(map);
             } else {
-                setSchedule(null);
+                setScheduleMap({});
             }
-        } catch (err: any) {
-            const msg =
-                err?.response?.data?.error?.message ||
-                "Failed to load today's schedule.";
-            toast.error(msg);
-            setSchedule(null);
+        } catch {
+            toast.error("Failed to load schedules for this month.");
+            setScheduleMap({});
         } finally {
             setIsLoading(false);
         }
-    };
+    }, []);
 
     useEffect(() => {
-        fetchTodaySchedule();
-    }, []);
+        fetchMonthSchedules(currentMonth);
+    }, [currentMonth, fetchMonthSchedules]);
 
     const handleScheduleSubmit = async (payload: CreateScheduleRequest) => {
         try {
             await scheduleService.createSchedule(payload);
-            fetchTodaySchedule();
+            await fetchMonthSchedules(currentMonth);
             toast.success("Schedule created successfully!");
         } catch (err: any) {
             const msg =
@@ -60,51 +77,64 @@ export const Schedule: React.FC = () => {
         }
     };
 
-    const effectiveStatus: DayStatus | "weekend" =
-        schedule?.day_status ?? (isWeekendDay ? "weekend" : "normal");
+    if (isLoading) {
+        return <LoadingSpinner message="Loading schedule…" />;
+    }
 
+    const selectedEntry = scheduleMap[selectedDate] ?? null;
+    const isSelectedWeekend = isWeekend(new Date(selectedDate + "T12:00:00"));
+    const effectiveStatus =
+        selectedEntry?.day_status ?? (isSelectedWeekend ? "weekend" : "normal");
     const config = STATUS_CONFIG[effectiveStatus];
-
-    const meals: string[] = schedule?.available_meals
-        ? schedule.available_meals
+    const meals: string[] = selectedEntry?.available_meals
+        ? selectedEntry.available_meals
               .split(",")
               .map((m) => m.trim())
               .filter(Boolean)
         : [];
-
-    if (isLoading) {
-        return <LoadingSpinner message="Loading today's schedule…" />;
-    }
 
     return (
         <div className="font-display bg-[var(--color-background-light)] text-[var(--color-text-main)] min-h-screen flex flex-col overflow-x-hidden">
             <Header userName={user?.name} userRole={user?.role} />
             <Navbar />
 
-            <main className="flex-grow container mx-auto px-6 py-8 md:px-12 max-w-2xl flex flex-col">
-                <div className="flex flex-col md:flex-row md:items-end justify-between gap-6 mb-8">
+            <main className="flex-grow container mx-auto px-6 py-8 md:px-12 max-w-5xl flex flex-col gap-6">
+                {/* Page header */}
+                <div className="flex flex-col md:flex-row md:items-end justify-between gap-4">
                     <div>
                         <h2 className="text-4xl font-black text-left text-[var(--color-background-dark)] mb-2 tracking-tight">
-                            Today
+                            Schedule
                         </h2>
                         <p className="text-lg text-[var(--color-text-sub)] font-medium">
-                            {format(today, "EEEE, MMMM d, yyyy")}
+                            Monthly meal schedule overview
                         </p>
                     </div>
 
-                    {!schedule && !isWeekendDay && (
-                        <button
-                            onClick={() => setIsModalOpen(true)}
-                            className="px-5 py-3 rounded-xl bg-gradient-to-br from-[#fa8c47] to-[#e57a36] text-white font-bold shadow-[6px_6px_12px_#e6dccf,-6px_-6px_12px_#ffffff] hover:scale-[1.02] active:scale-[0.98] transition-all flex items-center gap-2 text-sm self-start md:self-auto"
-                        >
-                            <span className="material-symbols-outlined text-[18px]">
-                                add
-                            </span>
-                            Create Schedule
-                        </button>
-                    )}
+                    <button
+                        onClick={() => {
+                            setSelectedDate(format(today, "yyyy-MM-dd"));
+                            setIsModalOpen(true);
+                        }}
+                        className="px-5 py-3 rounded-xl bg-gradient-to-br from-[#fa8c47] to-[#e57a36] text-white font-bold shadow-[6px_6px_12px_#e6dccf,-6px_-6px_12px_#ffffff] hover:scale-[1.02] active:scale-[0.98] transition-all flex items-center gap-2 text-sm self-start md:self-auto"
+                    >
+                        <span className="material-symbols-outlined text-[18px]">
+                            add
+                        </span>
+                        Create Schedule
+                    </button>
                 </div>
 
+                {/* Calendar */}
+                <ScheduleCalendar
+                    currentMonth={currentMonth}
+                    scheduleMap={scheduleMap}
+                    selectedDate={selectedDate}
+                    onSelectDate={setSelectedDate}
+                    onPrevMonth={() => setCurrentMonth((m) => subMonths(m, 1))}
+                    onNextMonth={() => setCurrentMonth((m) => addMonths(m, 1))}
+                />
+
+                {/* Selected day detail */}
                 <div className="bg-[#FFFDF5] rounded-[2rem] border border-[#e6dccf] p-8 shadow-[var(--shadow-clay-card)]">
                     <div className="flex items-center gap-4 mb-6">
                         <div className="w-14 h-14 rounded-2xl flex items-center justify-center shadow-[var(--shadow-clay-button)] bg-white">
@@ -114,22 +144,34 @@ export const Schedule: React.FC = () => {
                         </div>
                         <div>
                             <p className="text-[10px] font-bold uppercase tracking-widest text-[var(--color-text-sub)] mb-0.5">
-                                Day Status
+                                {format(
+                                    new Date(selectedDate + "T12:00:00"),
+                                    "EEEE, MMMM d, yyyy",
+                                )}
                             </p>
                             <h3 className="text-2xl font-black tracking-tight text-[var(--color-background-dark)]">
                                 {config.label}
                             </h3>
                         </div>
+
+                        {/* Status badge */}
+                        {selectedEntry && (
+                            <span
+                                className={`ml-auto px-3 py-1 rounded-xl text-xs font-semibold border ${STATUS_COLORS_FOR_SCHEDULE[selectedEntry.day_status]}`}
+                            >
+                                {STATUS_CONFIG[selectedEntry.day_status]?.label ?? selectedEntry.day_status}
+                            </span>
+                        )}
                     </div>
 
                     <div className="border-t border-[#e6dccf] pt-6 flex flex-col gap-5">
-                        {schedule?.reason && (
+                        {selectedEntry?.reason && (
                             <div>
                                 <p className="text-[10px] font-bold uppercase tracking-widest text-[var(--color-text-sub)] mb-1.5">
                                     Note
                                 </p>
                                 <p className="text-[var(--color-text-main)] font-medium">
-                                    {schedule.reason}
+                                    {selectedEntry.reason}
                                 </p>
                             </div>
                         )}
@@ -152,38 +194,35 @@ export const Schedule: React.FC = () => {
                             </div>
                         )}
 
-                        {schedule && (
-                            <button
-                                onClick={() => setIsModalOpen(true)}
-                                className="self-start mt-2 px-4 py-2 rounded-xl bg-[var(--color-background-light)] text-[var(--color-text-sub)] font-semibold shadow-[var(--shadow-clay-button)] hover:text-[var(--color-primary)] active:shadow-[var(--shadow-clay-button-active)] transition-all flex items-center gap-2 text-sm"
-                            >
-                                <span className="material-symbols-outlined text-[18px]">
-                                    add
+                        {!selectedEntry && !isSelectedWeekend && (
+                            <div className="bg-[var(--color-background-light)] border border-[#e6dccf] px-5 py-3 rounded-2xl text-sm text-[var(--color-text-sub)] flex items-center gap-3">
+                                <span className="material-symbols-outlined text-[20px]">
+                                    info
                                 </span>
-                                Create Schedule
-                            </button>
+                                No schedule set for this day.
+                            </div>
                         )}
+
+                        {!selectedEntry && isSelectedWeekend && (
+                            <div className="bg-[var(--color-background-light)] border border-[#e6dccf] px-5 py-3 rounded-2xl text-sm text-[var(--color-text-sub)] flex items-center gap-3">
+                                <span className="material-symbols-outlined text-[20px]">
+                                    info
+                                </span>
+                                It's a weekend — no schedule needed.
+                            </div>
+                        )}
+
+                        <button
+                            onClick={() => setIsModalOpen(true)}
+                            className="self-start mt-2 px-4 py-2 rounded-xl bg-[var(--color-background-light)] text-[var(--color-text-sub)] font-semibold shadow-[var(--shadow-clay-button)] hover:text-[var(--color-primary)] active:shadow-[var(--shadow-clay-button-active)] transition-all flex items-center gap-2 text-sm"
+                        >
+                            <span className="material-symbols-outlined text-[18px]">
+                                add
+                            </span>
+                            {selectedEntry ? "Create Another" : "Create Schedule"}
+                        </button>
                     </div>
                 </div>
-
-                {!schedule && isWeekendDay && (
-                    <div className="mt-6 bg-[#FFFDF5] border border-[#e6dccf] text-[var(--color-text-sub)] px-6 py-4 rounded-2xl text-sm flex items-center gap-3">
-                        <span className="material-symbols-outlined text-[20px]">
-                            info
-                        </span>
-                        It's the weekend — no schedule needed.
-                    </div>
-                )}
-
-                {!schedule && !isWeekendDay && (
-                    <div className="mt-6 bg-[#FFFDF5] border border-[#e6dccf] px-6 py-4 rounded-2xl text-sm text-[var(--color-text-sub)] flex items-center gap-3">
-                        <span className="material-symbols-outlined text-[20px]">
-                            info
-                        </span>
-                        No schedule has been created for today yet. Use the
-                        button above to add one.
-                    </div>
-                )}
             </main>
 
             <Footer
@@ -198,7 +237,7 @@ export const Schedule: React.FC = () => {
                 isOpen={isModalOpen}
                 onClose={() => setIsModalOpen(false)}
                 onSubmit={handleScheduleSubmit}
-                defaultDate={todayKey}
+                defaultDate={selectedDate}
             />
         </div>
     );

--- a/01-task-1-craftsbite/craftsbite-frontend/src/services/scheduleService.ts
+++ b/01-task-1-craftsbite/craftsbite-frontend/src/services/scheduleService.ts
@@ -20,3 +20,13 @@ export async function getScheduleByDate(
     );
     return response.data;
 }
+
+export async function getScheduleRange(
+    startDate: string,
+    endDate: string,
+): Promise<ApiResponse<ScheduleEntry[]>> {
+    const response = await api.get<ApiResponse<ScheduleEntry[]>>(
+        `/schedules/range?start_date=${startDate}&end_date=${endDate}`,
+    );
+    return response.data;
+}

--- a/01-task-1-craftsbite/craftsbite-frontend/src/types/meal.types.ts
+++ b/01-task-1-craftsbite/craftsbite-frontend/src/types/meal.types.ts
@@ -11,7 +11,9 @@ export type DayStatus =
   | "normal"
   | "office_closed"
   | "govt_holiday"
-  | "celebration";
+  | "celebration"
+  | "weekend"
+  | "event_day";
 
 export type MealPreference = "opt_in" | "opt_out";
 

--- a/01-task-1-craftsbite/craftsbite-frontend/src/types/schedule.types.ts
+++ b/01-task-1-craftsbite/craftsbite-frontend/src/types/schedule.types.ts
@@ -5,6 +5,8 @@ export const DAY_STATUS_OPTIONS: { value: DayStatus; label: string }[] = [
     { value: "office_closed", label: "Office Closed" },
     { value: "govt_holiday", label: "Govt Holiday" },
     { value: "celebration", label: "Celebration" },
+    { value: "weekend", label: "Weekend" },
+    { value: "event_day", label: "Event Day" },
 ];
 
 export const MEAL_OPTIONS: { value: MealType; label: string }[] = [
@@ -24,6 +26,7 @@ export const STATUS_CONFIG: Record<
     celebration: { icon: "celebration", label: "Celebration" },
     office_closed: { icon: "lock", label: "Office Closed" },
     weekend: { icon: "weekend", label: "Weekend" },
+    event_day: { icon: "star", label: "Event Day" },
 };
 
 export const MEAL_LABELS: Record<string, string> = {
@@ -65,3 +68,12 @@ export interface UpdateScheduleRequest {
     reason?: string;
     available_meals?: MealType[];
 }
+
+export const STATUS_COLORS_FOR_SCHEDULE: Record<string, string> = {
+    normal: "bg-emerald-700 text-emerald-800 border-emerald-400",
+    office_closed: "bg-red-700 text-red-800 border-red-400",
+    govt_holiday: "bg-sky-700 text-sky-800 border-sky-400",
+    celebration: "bg-violet-700 text-violet-800 border-violet-400",
+    weekend: "bg-[#ede8df] text-[var(--color-text-sub)] border-[#d6ccc0]",
+    event_day: "bg-orange-400 text-orange-800 border-orange-400",
+};

--- a/01-task-1-craftsbite/craftsbite-frontend/src/utils/constants.ts
+++ b/01-task-1-craftsbite/craftsbite-frontend/src/utils/constants.ts
@@ -20,6 +20,8 @@ export const DAY_STATUSES: Record<DayStatus, string> = {
     office_closed: 'Office Closed',
     govt_holiday: 'Government Holiday',
     celebration: 'Celebration',
+    weekend: 'Weekend',
+    event_day: 'Event Day'
 };
 
 // User Roles


### PR DESCRIPTION
<!-- Link to the issue this PR addresses -->
Closes #24 

## Dependencies

- _(none needed)_

## What does this PR do?

Adds `event_day` as a valid day status end-to-end — backend validation, TypeScript types, modal dropdown, schedule card display, and calendar dot/legend.

## Type of Change

- [x] New feature


## What was changed

**Backend** (`enums.go`): Added `DayStatusEventDay = "event_day"` constant and included it in the `IsValid()` switch. The `day_schedules.day_status` column is `VARCHAR(50)` so no migration needed.

**Frontend types** (`meal.types.ts`, `schedule.types.ts`): Added `"event_day"` to the `DayStatus` union, `DAY_STATUS_OPTIONS` (renders the button in the modal automatically), and `STATUS_CONFIG` with icon `star` and label `"Event Day"`.

**Calendar** (`ScheduleCalendar.tsx`): Added `event_day` to `DOT_COLORS` (`bg-orange-400`) and `LEGEND`. This wasn't in the original spec but was an obvious gap — without it, event day entries render a gray fallback dot and are absent from the legend.

The modal's `showMeals` logic (`dayStatus !== "office_closed"`) already handles event days correctly — meal selection including Event Dinner is shown without any JSX changes.

## Changelog

Feature: Admins/Logistics can now create Event Day schedules with Event Dinner as an available meal option.

## How to Test

1. Log in as Admin → Schedule → Create Schedule
2. Confirm **Event Day** button appears in the Day Status row
3. Select Event Day → confirm meal options including **Event Dinner** are visible
4. Submit with reason and meals → confirm the schedule card shows the `star` icon, "Event Day" label, and correct meals
5. Confirm the calendar shows an orange dot on that date with "Event Day" in the legend

## How QA Should Test

Affected workflows: schedule creation, schedule display card, calendar view, employee meal participation

- Verify submitting `day_status: "event_day"` via API returns `201` (not `400`)
- Verify Event Dinner appears as a toggleable meal for the employee on the Home page for that date
- Verify a previously created `event_day` schedule displays correctly on the calendar

## Rollback Plan

Revert this PR. No migrations or data changes were made.

## Checklist

- [x] My code follows the project style guidelines
- [x] Code passes linting and type checks