### PR TITLE
[PR-13] feat: add future meal participation planning with headcount forecast support

### DIFF
--- a/01-task-1-craftsbite/craftsbite-backend/internal/config/config.go
+++ b/01-task-1-craftsbite/craftsbite-backend/internal/config/config.go
@@ -55,6 +55,7 @@ type MealConfig struct {
     CutoffTime     string
     CutoffTimezone string
     WeekendDays    []string
+    ForwardWindowDays int
 }
 
 type CleanupConfig struct {
@@ -114,6 +115,7 @@ func LoadConfig() (*Config, error) {
             CutoffTime:     viper.GetString("MEAL_CUTOFF_TIME"),
             CutoffTimezone: viper.GetString("MEAL_CUTOFF_TIMEZONE"),
             WeekendDays:    parseCommaSeparated(viper.GetString("MEAL_WEEKEND_DAYS")),
+            ForwardWindowDays: viper.GetInt("MEAL_FORWARD_WINDOW_DAYS"),
         },
         Cleanup: CleanupConfig{
             RetentionMonths: viper.GetInt("HISTORY_RETENTION_MONTHS"),
@@ -156,13 +158,14 @@ func setDefaults() {
     viper.SetDefault("MEAL_CUTOFF_TIME", "21:00")
     viper.SetDefault("MEAL_CUTOFF_TIMEZONE", "Asia/Dhaka")
     viper.SetDefault("MEAL_WEEKEND_DAYS", "Saturday,Sunday")
+    viper.SetDefault("MEAL_FORWARD_WINDOW_DAYS", 7)
 
     viper.SetDefault("HISTORY_RETENTION_MONTHS", 3)
     viper.SetDefault("CLEANUP_CRON", "0 2 * * *")
 
     viper.SetDefault("RATE_LIMIT_ENABLED", true)
     viper.SetDefault("RATE_LIMIT_REQUESTS_PER_MINUTE", 100)
-}
+}   
 
 func (c *Config) Validate() error {
     if c.JWT.Secret == "" {

--- a/01-task-1-craftsbite/craftsbite-backend/internal/services/headcount_service.go
+++ b/01-task-1-craftsbite/craftsbite-backend/internal/services/headcount_service.go
@@ -131,7 +131,7 @@ func (s *headcountService) getHeadcountByDate(date string) (*DailyHeadcountSumma
 		return nil, err
 	}
 	if schedule == nil {
-		return nil, fmt.Errorf("no schedule set for %s", date)
+		return nil, nil
 	}
 
 	dayStatus := schedule.DayStatus
@@ -140,7 +140,7 @@ func (s *headcountService) getHeadcountByDate(date string) (*DailyHeadcountSumma
 		availableMeals = parseMealTypes(*schedule.AvailableMeals)
 	}
 	if len(availableMeals) == 0 {
-		return nil, fmt.Errorf("no meals configured for %s", date)
+		return nil, nil
 	}
 
 	totalActiveUsers := len(users)

--- a/01-task-1-craftsbite/craftsbite-frontend/src/components/cards/MealParticipationCard.tsx
+++ b/01-task-1-craftsbite/craftsbite-frontend/src/components/cards/MealParticipationCard.tsx
@@ -1,0 +1,295 @@
+import React, { useState, useEffect } from "react";
+import { MEAL_OPTIONS } from "../../types/schedule.types";
+import * as mealService from "../../services/mealService";
+import toast from "react-hot-toast";
+import type { MealType } from "../../types";
+import { FORWARD_WINDOW_DAYS } from "../../utils";
+
+
+function getTodayDateStr(): string {
+    return new Date().toISOString().split("T")[0];
+}
+
+function getMaxDateStr(): string {
+    const d = new Date();
+    d.setDate(d.getDate() + FORWARD_WINDOW_DAYS);
+    return d.toISOString().split("T")[0];
+}
+
+function getTomorrowDateStr(): string {
+    const d = new Date();
+    d.setDate(d.getDate() + 1);
+    return d.toISOString().split("T")[0];
+}
+
+// ─── Modal ───────────────────────────────────────────────────────────────────
+
+interface SetMealParticipationModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    onSuccess: () => void;
+}
+
+const SetMealParticipationModal: React.FC<SetMealParticipationModalProps> = ({
+    isOpen,
+    onClose,
+    onSuccess,
+}) => {
+    const [date, setDate] = useState(getTomorrowDateStr());
+    const [selectedMeals, setSelectedMeals] = useState<MealType[]>([]);
+    const [participating, setParticipating] = useState(true);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [error, setError] = useState("");
+
+    useEffect(() => {
+        if (isOpen) {
+            setDate(getTomorrowDateStr());
+            setSelectedMeals([]);
+            setParticipating(true);
+            setError("");
+        }
+    }, [isOpen]);
+
+    const allSelected = MEAL_OPTIONS.every((o) => selectedMeals.includes(o.value));
+
+    const toggleAll = () => {
+        setSelectedMeals(allSelected ? [] : MEAL_OPTIONS.map((o) => o.value));
+    };
+
+    const toggleMeal = (meal: MealType) => {
+        setSelectedMeals((prev) =>
+            prev.includes(meal) ? prev.filter((m) => m !== meal) : [...prev, meal],
+        );
+    };
+
+    const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        if (!date || selectedMeals.length === 0) return;
+
+        try {
+            setIsSubmitting(true);
+            setError("");
+
+            await Promise.all(
+                selectedMeals.map((meal) =>
+                    mealService.setMealParticipation({
+                        date,
+                        meal_type: meal,
+                        participating,
+                    }),
+                ),
+            );
+
+            toast.success(`Participation ${participating ? "confirmed" : "cancelled"}!`);
+            onSuccess();
+            onClose();
+        } catch (err: any) {
+            const msg =
+                err?.response?.data?.error?.message ||
+                "Failed to update meal participation.";
+            setError(msg);
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    if (!isOpen) return null;
+
+    return (
+        <div
+            className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/30 backdrop-blur-sm"
+            onClick={(e) => e.target === e.currentTarget && onClose()}
+        >
+            <div className="w-full max-w-md bg-[#FFFDF5] rounded-[2rem] border border-[#e6dccf] shadow-[var(--shadow-clay-card)] p-8 flex flex-col gap-6">
+                {/* Header */}
+                <div className="flex items-center justify-between">
+                    <h2 className="text-2xl font-black tracking-tight text-[var(--color-background-dark)]">
+                        Meal Participation
+                    </h2>
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        className="w-9 h-9 flex items-center justify-center rounded-xl text-[var(--color-text-sub)] hover:text-[var(--color-text-main)] hover:bg-[var(--color-background-light)] transition-all"
+                    >
+                        <span className="material-symbols-outlined text-[20px]">close</span>
+                    </button>
+                </div>
+
+                <form onSubmit={handleSubmit} className="flex flex-col gap-5">
+                    {/* Error */}
+                    {error && (
+                        <div className="flex items-center gap-3 p-4 rounded-xl bg-red-50 border border-red-200">
+                            <div>
+                                <p className="text-sm font-semibold text-red-600">Error</p>
+                                <p className="text-sm text-red-600 mt-1">{error}</p>
+                            </div>
+                        </div>
+                    )}
+
+                    {/* Date */}
+                    <div className="flex flex-col gap-1.5">
+                        <label className="text-[10px] font-bold uppercase tracking-widest text-[var(--color-text-sub)]">
+                            Date
+                        </label>
+                        <input
+                            type="date"
+                            required
+                            value={date}
+                            min={getTodayDateStr()}
+                            max={getMaxDateStr()}
+                            onChange={(e) => setDate(e.target.value)}
+                            className="w-full px-4 py-2.5 rounded-xl border border-[#e6dccf] bg-[var(--color-background-light)] text-[var(--color-text-main)] text-sm font-medium shadow-[var(--shadow-clay-button)] outline-none focus:border-[var(--color-primary)] transition-all"
+                        />
+                        <p className="text-[11px] text-[var(--color-text-sub)] opacity-70 ml-1">
+                            You can update participation up to {FORWARD_WINDOW_DAYS} days ahead.
+                        </p>
+                    </div>
+
+                    {/* Participating toggle */}
+                    <div className="flex flex-col gap-1.5">
+                        <label className="text-[10px] font-bold uppercase tracking-widest text-[var(--color-text-sub)]">
+                            Participation
+                        </label>
+                        <div className="grid grid-cols-2 gap-2">
+                            <button
+                                type="button"
+                                onClick={() => setParticipating(true)}
+                                className={`px-4 py-2.5 rounded-xl border text-sm font-semibold transition-all flex items-center justify-center gap-2 ${
+                                    participating
+                                        ? "bg-[var(--color-background-dark)] border-[var(--color-background-dark)] text-white shadow-[var(--shadow-clay-button)]"
+                                        : "bg-[var(--color-background-light)] border-[#e6dccf] text-[var(--color-text-sub)] shadow-[var(--shadow-clay-button)] hover:text-[var(--color-text-main)]"
+                                }`}
+                            >
+                                <span className="material-symbols-outlined text-[16px]">check_circle</span>
+                                Opting In
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => setParticipating(false)}
+                                className={`px-4 py-2.5 rounded-xl border text-sm font-semibold transition-all flex items-center justify-center gap-2 ${
+                                    !participating
+                                        ? "bg-[var(--color-background-dark)] border-[var(--color-background-dark)] text-white shadow-[var(--shadow-clay-button)]"
+                                        : "bg-[var(--color-background-light)] border-[#e6dccf] text-[var(--color-text-sub)] shadow-[var(--shadow-clay-button)] hover:text-[var(--color-text-main)]"
+                                }`}
+                            >
+                                <span className="material-symbols-outlined text-[16px]">cancel</span>
+                                Opting Out
+                            </button>
+                        </div>
+                    </div>
+
+                    {/* Meals */}
+                    <div className="flex flex-col gap-1.5">
+                        <label className="text-[10px] font-bold uppercase tracking-widest text-[var(--color-text-sub)]">
+                            Meals
+                        </label>
+                        <div className="flex flex-wrap gap-2">
+                            <button
+                                type="button"
+                                onClick={toggleAll}
+                                className={`px-3 py-1.5 rounded-xl border text-xs font-semibold transition-all ${
+                                    allSelected
+                                        ? "bg-[var(--color-background-dark)] border-[var(--color-background-dark)] text-white"
+                                        : "bg-[var(--color-background-light)] border-[#e6dccf] text-[var(--color-text-sub)] shadow-[var(--shadow-clay-button)] hover:text-[var(--color-text-main)]"
+                                }`}
+                            >
+                                All
+                            </button>
+
+                            {MEAL_OPTIONS.map((opt) => (
+                                <button
+                                    key={opt.value}
+                                    type="button"
+                                    onClick={() => toggleMeal(opt.value)}
+                                    className={`px-3 py-1.5 rounded-xl border text-xs font-semibold transition-all ${
+                                        selectedMeals.includes(opt.value)
+                                            ? "bg-[var(--color-background-dark)] border-[var(--color-background-dark)] text-white"
+                                            : "bg-[var(--color-background-light)] border-[#e6dccf] text-[var(--color-text-sub)] shadow-[var(--shadow-clay-button)] hover:text-[var(--color-text-main)]"
+                                    }`}
+                                >
+                                    {opt.label}
+                                </button>
+                            ))}
+                        </div>
+                    </div>
+
+                    <div className="border-t border-[#e6dccf]" />
+
+                    {/* Actions */}
+                    <div className="flex items-center justify-end gap-3">
+                        <button
+                            type="button"
+                            onClick={onClose}
+                            className="px-4 py-2.5 rounded-xl border border-[#e6dccf] bg-[var(--color-background-light)] text-[var(--color-text-sub)] text-sm font-semibold shadow-[var(--shadow-clay-button)] hover:text-[var(--color-text-main)] active:shadow-[var(--shadow-clay-button-active)] transition-all"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="submit"
+                            disabled={!date || selectedMeals.length === 0 || isSubmitting}
+                            className="px-5 py-2.5 rounded-xl bg-gradient-to-br from-[#fa8c47] to-[#e57a36] text-white text-sm font-bold shadow-[6px_6px_12px_#e6dccf,-6px_-6px_12px_#ffffff] hover:scale-[1.02] active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100 transition-all flex items-center gap-2"
+                        >
+                            {isSubmitting ? (
+                                <>
+                                    <span className="material-symbols-outlined text-[16px] animate-spin">
+                                        progress_activity
+                                    </span>
+                                    Saving…
+                                </>
+                            ) : (
+                                <>
+                                    <span className="material-symbols-outlined text-[16px]">
+                                        check
+                                    </span>
+                                    Confirm
+                                </>
+                            )}
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    );
+};
+
+// ─── Card ────────────────────────────────────────────────────────────────────
+
+export const MealParticipationCard: React.FC = () => {
+    const [isModalOpen, setIsModalOpen] = useState(false);
+
+    return (
+        <>
+            <div className="mb-6 bg-[var(--color-background-light)] rounded-3xl p-6 md:p-8 flex flex-col md:flex-row items-center justify-between gap-6 border-2 border-white/50 shadow-[var(--shadow-clay)]">
+                <div className="flex items-center gap-3">
+                    <div className="w-12 h-12 rounded-full bg-[var(--color-primary)]/10 flex items-center justify-center text-[var(--color-primary)] shadow-[var(--shadow-clay-inset)]">
+                        <span className="material-symbols-outlined text-2xl">restaurant</span>
+                    </div>
+                    <div>
+                        <h3 className="text-xl font-bold text-left text-[var(--color-background-dark)]">
+                            Meal Participation
+                        </h3>
+                        <p className="text-sm text-[var(--color-text-sub)]">
+                            Opt in or out of meals for any upcoming day
+                        </p>
+                    </div>
+                </div>
+
+                <button
+                    type="button"
+                    onClick={() => setIsModalOpen(true)}
+                    className="flex items-center gap-2 px-6 py-3 rounded-2xl bg-gradient-to-br from-[var(--color-primary)] to-[var(--color-primary-dark)] text-white font-bold text-sm hover:scale-[1.02] active:scale-[0.98] transition-all duration-200"
+                    style={{ boxShadow: "var(--shadow-clay-button)" }}
+                >
+                    <span className="material-symbols-outlined text-lg">edit_note</span>
+                    Set Participation
+                </button>
+            </div>
+
+            <SetMealParticipationModal
+                isOpen={isModalOpen}
+                onClose={() => setIsModalOpen(false)}
+                onSuccess={() => {}}
+            />
+        </>
+    );
+};

--- a/01-task-1-craftsbite/craftsbite-frontend/src/pages/HeadcountDashboard.tsx
+++ b/01-task-1-craftsbite/craftsbite-frontend/src/pages/HeadcountDashboard.tsx
@@ -71,8 +71,8 @@ export const HeadcountDashboard: React.FC = () => {
   useEffect(() => {
     if (streamData) {
       setHeadcountData(streamData);
-      setIsLoading(false);
     }
+    setIsLoading(false);
   }, [streamData]);
 
   const getMealLabel = (mealType: string): string =>

--- a/01-task-1-craftsbite/craftsbite-frontend/src/pages/Home.tsx
+++ b/01-task-1-craftsbite/craftsbite-frontend/src/pages/Home.tsx
@@ -14,6 +14,7 @@ import * as mealService from "../services/mealService";
 import { CUTOFF_TIMES } from "../utils/constants";
 import toast from "react-hot-toast";
 import { getTeamDetails } from "../services/userService";
+import { MealParticipationCard } from "../components/cards/MealParticipationCard";
 
 /**
  * Returns true if the cutoff time (9 PM) has passed today.
@@ -212,7 +213,10 @@ export const Home: React.FC = () => {
         </div>
             
         {user?.role === 'employee' && (
-          <WorkLocationCard />
+          <>
+            <WorkLocationCard />
+            <MealParticipationCard />
+          </>
         )}
 
         {/* Meal Cards Grid */}

--- a/01-task-1-craftsbite/craftsbite-frontend/src/utils/constants.ts
+++ b/01-task-1-craftsbite/craftsbite-frontend/src/utils/constants.ts
@@ -5,6 +5,8 @@ import type { MealType, DayStatus, UserRole } from '../types';
 // API Configuration
 export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api/v1';
 
+export const FORWARD_WINDOW_DAYS = import.meta.env.VITE_FORWARD_WINDOW_DAYS || 7;
+
 // Meal Types
 export const MEAL_TYPES: Record<MealType, string> = {
     lunch: 'Lunch',


### PR DESCRIPTION
Closes #26 

## Dependencies

- _(none needed)_

## What does this PR do?

Adds future meal participation planning for employees and unblocks headcount forecasting for admins on dates with no schedule yet.

## Type of Change

- [x] New feature
- [x] Bug fix

## What was changed

**Frontend:**
- `MealParticipationCard` added to `Home.tsx` for `role === "employee"` only (alongside the existing `WorkLocationCard`). The card opens a modal where the employee picks a date, selects meals, and toggles opt in/out. All selected meals are submitted as individual `setMealParticipation` calls.
- Date picker is constrained to today → `FORWARD_WINDOW_DAYS` ahead via `min`/`max` attributes.
- `FORWARD_WINDOW_DAYS` moved to constants, driven by `VITE_FORWARD_WINDOW_DAYS` env var (defaults to `7`).
- `HeadcountDashboard`: `setIsLoading(false)` now also fires on `streamError` so the loading screen doesn't hang when the stream fails.

**Backend (`headcount_service.go`):**
- `getHeadcountByDate` now returns `nil, nil` (instead of an error) when no schedule is found or no meals are configured. This lets admins query future dates and get an empty state rather than a 500/error response.

## Changelog

Feature: Employees can now set meal participation for upcoming dates from the Home page.

## How to Test

1. Log in as **Employee** → Home page → confirm **Meal Participation** card is visible.
2. Click **Set Participation** → pick a future date within 7 days → select meals → toggle opt in/out → confirm.
3. Log in as **Admin** → Headcount Dashboard → Pick Date → select a future date with no schedule → confirm empty state renders (no error, no stuck loading screen).
4. Pick a future date that has a schedule and participation records → confirm headcount forecast renders correctly.

## How QA Should Test

Affected workflows: employee home page, meal participation, headcount dashboard date picker.

- Verify the Meal Participation card is **not visible** for Admin or Logistics roles.
- Verify the date picker enforces the forward window — dates beyond `FORWARD_WINDOW_DAYS` should not be selectable.
- Verify opting out correctly sends `participating: false` to the API.
- Verify querying a date with no schedule on the Headcount Dashboard shows an empty state, not an error.
- Verify the loading spinner on the Headcount Dashboard dismisses correctly when the stream errors.

## Rollback Plan

Revert this PR. No DB migrations or breaking API changes were made. Set `VITE_FORWARD_WINDOW_DAYS` back if the env var was added to production config.

## Checklist

- [x] My code follows the project style guidelines
- [x] Code passes linting and type checks
- [ ] I have added tests for my changes (if applicable)

## Note for Reviewer

The `getHeadcountByDate` nil return is intentional — check that the frontend handles `res.data === null` cleanly in all dashboard paths.