### PR TITLE
[PR-16] feat: WFH over-limit badge and monthly WFH report endpoint with view

### DIFF
--- a/01-task-1-craftsbite/craftsbite-backend/cmd/server/main.go
+++ b/01-task-1-craftsbite/craftsbite-backend/cmd/server/main.go
@@ -83,7 +83,7 @@ func main() {
 	authService := services.NewAuthService(userRepo, cfg)
 	userService := services.NewUserService(userRepo, teamRepo)
 	participationResolver := services.NewParticipationResolver(mealRepo, scheduleRepo, bulkOptOutRepo, userRepo, cfg)
-	mealService := services.NewMealService(mealRepo, scheduleRepo, historyRepo, userRepo, teamRepo, participationResolver, cfg)
+	mealService := services.NewMealService(mealRepo, scheduleRepo, historyRepo, userRepo, teamRepo, workLocationRepo, participationResolver, cfg)
 	scheduleService := services.NewScheduleService(scheduleRepo)
 	headcountService := services.NewHeadcountService(userRepo, scheduleRepo, participationResolver, teamRepo, workLocationRepo, wfhPeriodRepo)
 	workLocationService := services.NewWorkLocationService(workLocationRepo, userRepo, teamRepo, wfhPeriodRepo, workLocationHistoryRepo, cfg)

--- a/01-task-1-craftsbite/craftsbite-backend/internal/handlers/work_location_handler.go
+++ b/01-task-1-craftsbite/craftsbite-backend/internal/handlers/work_location_handler.go
@@ -137,3 +137,24 @@ func (h *WorkLocationHandler) GetMonthlySummary(c *gin.Context) {
 
     utils.SuccessResponse(c, 200, summary, "Monthly WFH summary retrieved")
 }
+
+func (h *WorkLocationHandler) GetTeamMonthlyReport(c *gin.Context) {
+    requesterID, exists := c.Get("user_id")
+    if !exists {
+        utils.ErrorResponse(c, 401, "UNAUTHORIZED", "User not authenticated")
+        return
+    }
+
+    yearMonth := c.Query("month")
+    if yearMonth == "" {
+        yearMonth = time.Now().Format("2006-01")
+    }
+
+    rollup, err := h.svc.GetTeamMonthlyReport(requesterID.(string), yearMonth)
+    if err != nil {
+        utils.ErrorResponse(c, 400, "ROLLUP_ERROR", err.Error())
+        return
+    }
+
+    utils.SuccessResponse(c, 200, rollup, "Monthly WFH report retrieved")
+}

--- a/01-task-1-craftsbite/craftsbite-backend/internal/routes/routes.go
+++ b/01-task-1-craftsbite/craftsbite-backend/internal/routes/routes.go
@@ -148,6 +148,7 @@ func registerWorkLocationRoutes(v1 *gin.RouterGroup, h *Handlers, cfg *config.Co
         wl.GET("", h.WorkLocation.GetMyWorkLocation)
         wl.POST("", h.WorkLocation.SetMyWorkLocation)
         wl.GET("/monthly-summary", h.WorkLocation.GetMonthlySummary)
+        wl.GET("/team-monthly-report", middleware.RequireRoles(models.RoleAdmin, models.RoleLogistics, models.RoleTeamLead), h.WorkLocation.GetTeamMonthlyReport)
         
         wl.POST("/override", middleware.RequireRoles(models.RoleAdmin, models.RoleTeamLead), h.WorkLocation.SetWorkLocationFor)
         wl.GET("/list", middleware.RequireRoles(models.RoleAdmin, models.RoleTeamLead), h.WorkLocation.ListWorkLocationsByDate)

--- a/01-task-1-craftsbite/craftsbite-frontend/src/components/cards/WFHMonthlyReport.tsx
+++ b/01-task-1-craftsbite/craftsbite-frontend/src/components/cards/WFHMonthlyReport.tsx
@@ -1,0 +1,396 @@
+import React, { useState } from "react";
+import {
+    fetchWFHReport,
+    type TeamMonthlyReport,
+} from "../../services/workLocationService";
+
+interface WFHMonthlyReportProps {
+    memberNames?: Record<string, string>;
+}
+
+function formatMonthLabel(yearMonth: string): string {
+    const [year, month] = yearMonth.split("-");
+    const date = new Date(Number(year), Number(month) - 1, 1);
+    return date.toLocaleString("default", { month: "long", year: "numeric" });
+}
+
+function buildCopyText(
+    report: TeamMonthlyReport,
+    memberNames: Record<string, string>,
+): string {
+    const title = `WFH Monthly Report — ${formatMonthLabel(report.year_month)}`;
+    const divider = "─".repeat(56);
+    const summary = [
+        `Allowance : ${report.allowance} day${report.allowance !== 1 ? "s" : ""}`,
+        `Employees : ${report.total_employees}`,
+        `Over Limit: ${report.over_limit_count}`,
+        `Extra Days: ${report.total_extra_days}`,
+    ].join("   |   ");
+
+    const colName = "Name / ID";
+    const colUsed = "WFH Used";
+    const colLimit = "Over Limit";
+    const colExtra = "Extra Days";
+    const pad = (s: string, n: number) => s.padEnd(n);
+
+    const header = `${pad(colName, 28)}${pad(colUsed, 12)}${pad(colLimit, 12)}${colExtra}`;
+    const rows = [...report.members]
+        .sort((a, b) => Number(b.is_over_limit) - Number(a.is_over_limit))
+        .map((m) => {
+            const name = memberNames[m.user_id] ?? m.user_id;
+            return `${pad(name, 28)}${pad(String(m.wfh_days), 12)}${pad(m.is_over_limit ? "⚠ Yes" : "No", 12)}${m.extra_days > 0 ? `+${m.extra_days}` : m.extra_days}`;
+        });
+
+    return [
+        title,
+        divider,
+        summary,
+        "",
+        divider,
+        header,
+        divider,
+        ...rows,
+        divider,
+    ].join("\n");
+}
+
+export const WFHMonthlyReport: React.FC<WFHMonthlyReportProps> = ({
+    memberNames = {},
+}) => {
+    const currentMonth = new Date().toISOString().slice(0, 7);
+    const [selectedMonth, setSelectedMonth] = useState(currentMonth);
+    const [report, setReport] = useState<TeamMonthlyReport | null>(null);
+    const [isLoading, setIsLoading] = useState(false);
+    const [error, setError] = useState<string>("");
+    const [copied, setCopied] = useState(false);
+
+    const handleFetch = async () => {
+        setError("");
+        setReport(null);
+        setIsLoading(true);
+        try {
+            const res = await fetchWFHReport(selectedMonth);
+            if (res.success && res.data) {
+                setReport(res.data);
+            } else {
+                setError("No report data returned.");
+            }
+        } catch (err: any) {
+            setError(
+                err?.response?.data?.error?.message ??
+                    err?.message ??
+                    "Failed to fetch WFH report.",
+            );
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    const handleCopy = async () => {
+        if (!report) return;
+        const text = buildCopyText(report, memberNames);
+        try {
+            await navigator.clipboard.writeText(text);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
+        } catch {
+            const el = document.createElement("textarea");
+            el.value = text;
+            document.body.appendChild(el);
+            el.select();
+            document.execCommand("copy");
+            document.body.removeChild(el);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
+        }
+    };
+
+    const sortedMembers = report
+        ? [...report.members].sort(
+              (a, b) => Number(b.is_over_limit) - Number(a.is_over_limit),
+          )
+        : [];
+
+    return (
+        <div className="bg-[#FFFDF5] rounded-[2rem] border border-[#e6dccf] shadow-[var(--shadow-clay-card)] p-6 md:p-8 flex flex-col gap-6">
+            <div className="flex flex-col sm:flex-row sm:items-end justify-between gap-4">
+                <div>
+                    <h3 className="text-xl font-black tracking-tight text-[var(--color-background-dark)]">
+                        WFH Monthly Report
+                    </h3>
+                    <p className="text-sm text-[var(--color-text-sub)] font-medium mt-0.5">
+                        Team-wide work-from-home usage and allowance rollup.
+                    </p>
+                </div>
+
+                <div className="flex items-center gap-2 shrink-0">
+                    <input
+                        type="month"
+                        value={selectedMonth}
+                        onChange={(e) => setSelectedMonth(e.target.value)}
+                        className="px-4 py-2.5 rounded-xl border border-[#e6dccf] bg-[var(--color-background-light)] text-[var(--color-text-main)] text-sm font-medium shadow-[var(--shadow-clay-button)] outline-none focus:border-[var(--color-primary)] transition-all"
+                    />
+                    <button
+                        type="button"
+                        onClick={handleFetch}
+                        disabled={isLoading}
+                        className="px-5 py-2.5 rounded-xl bg-gradient-to-br from-[#fa8c47] to-[#e57a36] text-white text-sm font-bold shadow-[6px_6px_12px_#e6dccf,-6px_-6px_12px_#ffffff] hover:scale-[1.02] active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100 transition-all flex items-center gap-2"
+                    >
+                        {isLoading ? (
+                            <>
+                                <span className="material-symbols-outlined text-[16px] animate-spin">
+                                    progress_activity
+                                </span>
+                                Loading…
+                            </>
+                        ) : (
+                            <>
+                                <span className="material-symbols-outlined text-[16px]">
+                                    bar_chart
+                                </span>
+                                Fetch Report
+                            </>
+                        )}
+                    </button>
+                </div>
+            </div>
+
+            {error && (
+                <div className="flex items-start gap-3 p-4 rounded-xl bg-red-50 border border-red-200">
+                    <span className="material-symbols-outlined text-red-500 text-[20px] shrink-0 mt-0.5">
+                        error
+                    </span>
+                    <div>
+                        <p className="text-sm font-semibold text-red-600">
+                            Failed to load report
+                        </p>
+                        <p className="text-sm text-red-500 mt-0.5">{error}</p>
+                    </div>
+                </div>
+            )}
+
+            {!report && !error && !isLoading && (
+                <div className="flex flex-col items-center justify-center py-10 gap-3 text-center">
+                    <span className="material-symbols-outlined text-5xl text-[var(--color-text-sub)] opacity-30">
+                        home_work
+                    </span>
+                    <p className="text-sm font-semibold text-[var(--color-text-sub)] opacity-60">
+                        Select a month and click{" "}
+                        <span className="font-black">Fetch Report</span> to see
+                        the WFH rollup.
+                    </p>
+                </div>
+            )}
+
+            {report && (
+                <>
+                    <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                        <StatPill
+                            icon="calendar_month"
+                            label="Month"
+                            value={formatMonthLabel(report.year_month)}
+                            accent={false}
+                        />
+                        <StatPill
+                            icon="beach_access"
+                            label="WFH Allowance"
+                            value={`${report.allowance} day${report.allowance !== 1 ? "s" : ""}`}
+                            accent={false}
+                        />
+                        <StatPill
+                            icon="group"
+                            label="Employees"
+                            value={String(report.total_employees)}
+                            accent={false}
+                        />
+                        <StatPill
+                            icon="warning"
+                            label="Over Limit"
+                            value={`${report.over_limit_count} member${report.over_limit_count !== 1 ? "s" : ""}`}
+                            accent={report.over_limit_count > 0}
+                        />
+                    </div>
+
+                    {/* Extra-days callout */}
+                    {report.total_extra_days > 0 && (
+                        <div className="flex items-center gap-3 p-3.5 rounded-xl bg-amber-50 border border-amber-200">
+                            <span className="material-symbols-outlined text-amber-500 text-[20px] shrink-0">
+                                info
+                            </span>
+                            <p className="text-sm text-amber-700 font-semibold">
+                                {report.total_extra_days} extra WFH day
+                                {report.total_extra_days !== 1 ? "s" : ""}{" "}
+                                recorded above the allowance this month.
+                            </p>
+                        </div>
+                    )}
+
+                    <div className="overflow-x-auto -mx-1">
+                        <table className="w-full text-left border-separate border-spacing-y-2 min-w-[480px]">
+                            <thead>
+                                <tr>
+                                    <th className="text-[10px] font-bold uppercase tracking-widest text-[var(--color-text-sub)] py-2 px-4">
+                                        Member
+                                    </th>
+                                    <th className="text-[10px] font-bold uppercase tracking-widest text-[var(--color-text-sub)] py-2 px-4 text-center">
+                                        WFH Used
+                                    </th>
+                                    <th className="text-[10px] font-bold uppercase tracking-widest text-[var(--color-text-sub)] py-2 px-4 text-center">
+                                        Allowance
+                                    </th>
+                                    <th className="text-[10px] font-bold uppercase tracking-widest text-[var(--color-text-sub)] py-2 px-4 text-center">
+                                        Extra Days
+                                    </th>
+                                    <th className="text-[10px] font-bold uppercase tracking-widest text-[var(--color-text-sub)] py-2 px-4 text-center">
+                                        Status
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {sortedMembers.map((member) => {
+                                    const displayName =
+                                        memberNames[member.user_id] ??
+                                        member.user_id;
+                                    const initials = displayName
+                                        .split(/[\s_]/)
+                                        .map((p) => p[0]?.toUpperCase() ?? "")
+                                        .slice(0, 2)
+                                        .join("");
+
+                                    return (
+                                        <tr
+                                            key={member.user_id}
+                                            className={`rounded-xl ${
+                                                member.is_over_limit
+                                                    ? "bg-red-50/60"
+                                                    : "bg-white/40"
+                                            }`}
+                                        >
+                                            <td className="py-3 px-4 rounded-l-xl">
+                                                <div className="flex items-center gap-3">
+                                                    <div
+                                                        className={`w-9 h-9 rounded-full flex items-center justify-center text-xs font-bold shrink-0 ${
+                                                            member.is_over_limit
+                                                                ? "bg-red-100 text-red-700"
+                                                                : "bg-orange-100 text-orange-700"
+                                                        }`}
+                                                    >
+                                                        {initials}
+                                                    </div>
+                                                    <span className="font-bold text-sm text-[var(--color-background-dark)] break-all">
+                                                        {displayName}
+                                                    </span>
+                                                </div>
+                                            </td>
+
+                                            <td className="py-3 px-4 text-center">
+                                                <span className="font-bold text-sm text-[var(--color-background-dark)]">
+                                                    {member.wfh_days}
+                                                </span>
+                                            </td>
+
+                                            <td className="py-3 px-4 text-center">
+                                                <span className="text-sm font-medium text-[var(--color-text-sub)]">
+                                                    {report.allowance}
+                                                </span>
+                                            </td>
+
+                                            <td className="py-3 px-4 text-center">
+                                                {member.extra_days > 0 ? (
+                                                    <span className="inline-flex items-center gap-1 text-xs font-bold text-red-600 bg-red-50 border border-red-200 rounded-lg px-2 py-0.5">
+                                                        +{member.extra_days}
+                                                    </span>
+                                                ) : (
+                                                    <span className="text-sm text-[var(--color-text-sub)] opacity-50">
+                                                        —
+                                                    </span>
+                                                )}
+                                            </td>
+
+                                            <td className="py-3 px-4 rounded-r-xl text-center">
+                                                {member.is_over_limit ? (
+                                                    <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-bold bg-red-50 text-red-700 border border-red-200">
+                                                        <span className="material-symbols-outlined text-[14px]">
+                                                            warning
+                                                        </span>
+                                                        Over
+                                                    </span>
+                                                ) : (
+                                                    <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-bold bg-green-50 text-green-700 border border-green-200">
+                                                        <span className="material-symbols-outlined text-[14px]">
+                                                            check_circle
+                                                        </span>
+                                                        OK
+                                                    </span>
+                                                )}
+                                            </td>
+                                        </tr>
+                                    );
+                                })}
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div className="border-t border-[#e6dccf] pt-4 flex justify-end">
+                        <button
+                            type="button"
+                            onClick={handleCopy}
+                            className={`px-4 py-2.5 rounded-xl border text-sm font-semibold transition-all flex items-center gap-2 ${
+                                copied
+                                    ? "bg-green-50 border-green-200 text-green-700"
+                                    : "bg-[var(--color-background-light)] border-[#e6dccf] text-[var(--color-text-sub)] shadow-[var(--shadow-clay-button)] hover:text-[var(--color-text-main)] active:shadow-[var(--shadow-clay-button-active)]"
+                            }`}
+                        >
+                            <span className="material-symbols-outlined text-[16px]">
+                                {copied ? "check" : "content_copy"}
+                            </span>
+                            {copied ? "Copied!" : "Copy Report"}
+                        </button>
+                    </div>
+                </>
+            )}
+        </div>
+    );
+};
+
+/* ─── Small helper component ─── */
+interface StatPillProps {
+    icon: string;
+    label: string;
+    value: string;
+    accent: boolean;
+}
+
+const StatPill: React.FC<StatPillProps> = ({ icon, label, value, accent }) => (
+    <div
+        className={`flex flex-col gap-1.5 p-4 rounded-2xl border shadow-[var(--shadow-clay-button)] ${
+            accent
+                ? "bg-red-50 border-red-200"
+                : "bg-[var(--color-background-light)] border-[#e6dccf]"
+        }`}
+    >
+        <div className="flex items-center gap-1.5">
+            <span
+                className={`material-symbols-outlined text-[16px] ${
+                    accent ? "text-red-500" : "text-[var(--color-text-sub)]"
+                }`}
+            >
+                {icon}
+            </span>
+            <span
+                className={`text-[10px] font-bold uppercase tracking-widest ${
+                    accent ? "text-red-500" : "text-[var(--color-text-sub)]"
+                }`}
+            >
+                {label}
+            </span>
+        </div>
+        <p
+            className={`text-base font-black tracking-tight ${
+                accent ? "text-red-700" : "text-[var(--color-background-dark)]"
+            }`}
+        >
+            {value}
+        </p>
+    </div>
+);

--- a/01-task-1-craftsbite/craftsbite-frontend/src/components/cards/index.ts
+++ b/01-task-1-craftsbite/craftsbite-frontend/src/components/cards/index.ts
@@ -1,16 +1,18 @@
-export { EmployeeMenuCard } from './EmployeeMenuCard';
-export type { EmployeeMenuCardProps, MealType } from './EmployeeMenuCard';
+export { EmployeeMenuCard } from "./EmployeeMenuCard";
+export type { EmployeeMenuCardProps, MealType } from "./EmployeeMenuCard";
 
-export { InteractiveCard } from './InteractiveCard';
-export type { InteractiveCardProps } from './InteractiveCard';
+export { InteractiveCard } from "./InteractiveCard";
+export type { InteractiveCardProps } from "./InteractiveCard";
 
-export { StandardCard } from './StandardCard';
-export type { StandardCardProps } from './StandardCard';
+export { StandardCard } from "./StandardCard";
+export type { StandardCardProps } from "./StandardCard";
 
-export { AccentBorderCard } from './AccentBorderCard';
-export type { AccentBorderCardProps } from './AccentBorderCard';
+export { AccentBorderCard } from "./AccentBorderCard";
+export type { AccentBorderCardProps } from "./AccentBorderCard";
 
-export { WorkLocationCard } from './WorkLocationCard';
+export { WorkLocationCard } from "./WorkLocationCard";
 
-export { ScheduleCalendar } from './ScheduleCalender';
-export type { ScheduleCalendarProps } from './ScheduleCalender';
+export { ScheduleCalendar } from "./ScheduleCalender";
+export type { ScheduleCalendarProps } from "./ScheduleCalender";
+
+export { WFHMonthlyReport } from "./WFHMonthlyReport";

--- a/01-task-1-craftsbite/craftsbite-frontend/src/pages/TeamParticipation.tsx
+++ b/01-task-1-craftsbite/craftsbite-frontend/src/pages/TeamParticipation.tsx
@@ -229,12 +229,18 @@ export const TeamParticipation: React.FC = () => {
                               <div className="w-10 h-10 rounded-full bg-orange-100 flex items-center justify-center text-orange-700 font-bold text-sm shadow-sm shrink-0">
                                 {member.name.charAt(0)}
                               </div>
-                              <div>
-                                <p className="font-bold text-[var(--color-background-dark)]">{member.name}</p>
-                                {member.user_id === team.team_lead_user_id && (
-                                  <span className="text-xs text-orange-500 font-semibold">Team Lead</span>
-                                )}
-                              </div>
+                            <div>
+                              <p className="font-bold text-[var(--color-background-dark)]">{member.name}</p>
+                              {member.user_id === team.team_lead_user_id && (
+                                <span className="text-xs text-orange-500 font-semibold">Team Lead</span>
+                              )}
+                              {member.is_over_wfh_limit && (
+                                <span className="inline-flex items-center gap-1 text-[10px] font-bold text-red-600 bg-red-50 border border-red-200 rounded-lg px-2 py-0.5 mt-0.5">
+                                  <span className="material-symbols-outlined text-[12px]">warning</span>
+                                  WFH over limit
+                                </span>
+                              )}
+                            </div>
                             </div>
                           </td>
 

--- a/01-task-1-craftsbite/craftsbite-frontend/src/pages/TeamParticipation.tsx
+++ b/01-task-1-craftsbite/craftsbite-frontend/src/pages/TeamParticipation.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useMemo, useCallback } from "react";
 import { Header, Navbar, Footer, LoadingSpinner } from "../components";
+import { WFHMonthlyReport } from "../components/cards";
 import { useAuth } from "../contexts/AuthContext";
 import { getAllTeamsParticipation, getTeamParticipation, createBatchBulkOptOut } from "../services/mealService";
 import toast from "react-hot-toast";
@@ -16,6 +17,8 @@ export const TeamParticipation: React.FC = () => {
 
   const [teams, setTeams] = useState<TeamParticipationGroup[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+
+  const [showWFHReport, setShowWFHReport] = useState(false);
 
   const [panelStep, setPanelStep] = useState<PanelStep>(null);
   const [selectedUserIds, setSelectedUserIds] = useState<string[]>([]);
@@ -79,6 +82,11 @@ export const TeamParticipation: React.FC = () => {
   };
 
   const allSelected = allMembers.length > 0 && selectedUserIds.length === allMembers.length;
+
+  const memberNames = useMemo<Record<string, string>>(
+    () => Object.fromEntries(allMembers.map((m) => [m.user_id, m.name])),
+    [allMembers],
+  );
 
   const toggleMeal = (meal: string) =>
     setMealTypes((prev) =>
@@ -153,18 +161,32 @@ export const TeamParticipation: React.FC = () => {
           </div>
 
           {isPrivileged && panelStep === null && (
-            <button
-              type="button"
-              onClick={openPicker}
-              className="px-5 py-3 rounded-xl bg-gradient-to-br from-[#fa8c47] to-[#e57a36] text-white font-bold shadow-[6px_6px_12px_#e6dccf,-6px_-6px_12px_#ffffff] hover:scale-[1.02] active:scale-[0.98] transition-all flex items-center gap-2 text-sm self-start md:self-auto"
-            >
-              <span className="material-symbols-outlined text-[18px]">block</span>
-              Bulk Opt-Out
-            </button>
+            <div className="flex items-center gap-2 self-start md:self-auto flex-wrap">
+              <button
+                type="button"
+                onClick={() => setShowWFHReport((v) => !v)}
+                className={`px-5 py-3 rounded-xl font-bold transition-all flex items-center gap-2 text-sm ${
+                  showWFHReport
+                    ? "bg-[var(--color-background-dark)] text-white shadow-[6px_6px_12px_#e6dccf,-6px_-6px_12px_#ffffff] hover:scale-[1.02] active:scale-[0.98]"
+                    : "border border-[#e6dccf] bg-[var(--color-background-light)] text-[var(--color-text-sub)] shadow-[var(--shadow-clay-button)] hover:text-[var(--color-text-main)]"
+                }`}
+              >
+                <span className="material-symbols-outlined text-[18px]">home_work</span>
+                WFH Report
+              </button>
+              <button
+                type="button"
+                onClick={openPicker}
+                className="px-5 py-3 rounded-xl bg-gradient-to-br from-[#fa8c47] to-[#e57a36] text-white font-bold shadow-[6px_6px_12px_#e6dccf,-6px_-6px_12px_#ffffff] hover:scale-[1.02] active:scale-[0.98] transition-all flex items-center gap-2 text-sm"
+              >
+                <span className="material-symbols-outlined text-[18px]">block</span>
+                Bulk Opt-Out
+              </button>
+            </div>
           )}
         </div>
 
-        {!panelStep && mealColumns.length > 0 && (
+        {!panelStep && !showWFHReport && mealColumns.length > 0 && (
           <div className="bg-[#FFFDF5] rounded-[2rem] p-6 md:p-8 border border-[#e6dccf] shadow-[var(--shadow-clay-card)]">
             <div className="flex items-center justify-between mb-5">
               <div>
@@ -229,18 +251,18 @@ export const TeamParticipation: React.FC = () => {
                               <div className="w-10 h-10 rounded-full bg-orange-100 flex items-center justify-center text-orange-700 font-bold text-sm shadow-sm shrink-0">
                                 {member.name.charAt(0)}
                               </div>
-                            <div>
-                              <p className="font-bold text-[var(--color-background-dark)]">{member.name}</p>
-                              {member.user_id === team.team_lead_user_id && (
-                                <span className="text-xs text-orange-500 font-semibold">Team Lead</span>
-                              )}
-                              {member.is_over_wfh_limit && (
-                                <span className="inline-flex items-center gap-1 text-[10px] font-bold text-red-600 bg-red-50 border border-red-200 rounded-lg px-2 py-0.5 mt-0.5">
-                                  <span className="material-symbols-outlined text-[12px]">warning</span>
-                                  WFH over limit
-                                </span>
-                              )}
-                            </div>
+                              <div>
+                                <p className="font-bold text-[var(--color-background-dark)]">{member.name}</p>
+                                {member.user_id === team.team_lead_user_id && (
+                                  <span className="text-xs text-orange-500 font-semibold">Team Lead</span>
+                                )}
+                                {member.is_over_wfh_limit && (
+                                  <span className="inline-flex items-center gap-1 text-[10px] font-bold text-red-600 bg-red-50 border border-red-200 rounded-lg px-2 py-0.5 mt-0.5">
+                                    <span className="material-symbols-outlined text-[12px]">warning</span>
+                                    WFH over limit
+                                  </span>
+                                )}
+                              </div>
                             </div>
                           </td>
 
@@ -262,6 +284,10 @@ export const TeamParticipation: React.FC = () => {
           </div>
         </div>)
         }
+
+        {isPrivileged && showWFHReport && !panelStep && (
+          <WFHMonthlyReport memberNames={memberNames} />
+        )}
 
         {!panelStep && mealColumns.length === 0 && (
           <div className="bg-[#FFFDF5] rounded-[2rem] p-8 border border-[#e6dccf] shadow-[var(--shadow-clay-card)] flex flex-col items-center justify-center text-center gap-3 py-16">

--- a/01-task-1-craftsbite/craftsbite-frontend/src/services/workLocationService.ts
+++ b/01-task-1-craftsbite/craftsbite-frontend/src/services/workLocationService.ts
@@ -35,6 +35,22 @@ export interface MonthlyWFHSummary {
     is_over_limit: boolean;
 }
 
+export interface MemberWFHSummary {
+    user_id: string;
+    wfh_days: number;
+    is_over_limit: boolean;
+    extra_days: number;
+}
+
+export interface TeamMonthlyReport {
+    year_month: string;
+    allowance: number;
+    total_employees: number;
+    over_limit_count: number;
+    total_extra_days: number;
+    members: MemberWFHSummary[];
+}
+
 // ---------- API Calls ----------
 
 export async function setWorkLocation(
@@ -81,3 +97,14 @@ export async function getMonthlyWFHSummary(
     );
     return response.data;
 }
+
+export async function fetchWFHReport(month?: string): Promise<ApiResponse<TeamMonthlyReport>> {
+    const params = month ? `?month=${month}` : "";
+    
+    const response = await api.get<ApiResponse<TeamMonthlyReport>>(
+        `/work-location/team-monthly-report${params}`,
+    );
+
+    return response.data;
+}
+

--- a/01-task-1-craftsbite/craftsbite-frontend/src/types/team.types.ts
+++ b/01-task-1-craftsbite/craftsbite-frontend/src/types/team.types.ts
@@ -3,6 +3,7 @@ export interface TeamMemberParticipation {
   name: string;
   email: string;
   meals: Record<string, boolean>;
+  is_over_wfh_limit?: boolean;
 }
 
 export interface TeamParticipationGroup {


### PR DESCRIPTION
Closes #32 

## Dependencies

- _(none needed)_

## What does this PR do?

Adds a per-member WFH over-limit badge to the Team Participation table and a new monthly WFH rollup API endpoint with frontend type support.

## Type of Change

- [x] New feature

## What was changed

**Backend (`meal_service.go`):**
- Added `IsOverWFHLimit bool` to `TeamMemberParticipation` struct.
- Added `wlRepo` and `monthlyWFHAllowance` to `mealService`; updated `NewMealService` signature accordingly.
- Added `isOverWFHLimit(userID string) bool` helper — calls `CountWFHByUserAndMonth` and returns `false` on error (no false positives).
- Both `getTeamParticipationWithMeals` and `GetAllTeamsParticipation` now populate `IsOverWFHLimit` per member.

**Backend (`work_location_repository.go`):**
- Added `GetMonthlyWFHCountsByUsers(yearMonth string, userIDs []string) (map[string]int64, error)` — single `GROUP BY user_id` query; guards against empty ID slice.

**Backend (`work_location_service.go`):**
- Added `MemberWFHSummary` and `TeamMonthlyReport` structs.
- Added `GetTeamMonthlyReport(requesterID, yearMonth string)` — resolves member scope by role (team lead → own team; admin/logistics → all active users), calls the batched repo method, computes per-member `IsOverLimit`/`ExtraDays`, and accumulates rollup totals.

**Backend (`work_location_handler.go` + `routes.go`):**
- Added `GetTeamMonthlyReport` handler; `month` param defaults to current month.
- Registered `GET /api/v1/work-location/team-monthly-report` with `RequireRoles(admin, logistics, team_lead)`.

**Frontend (`team.types.ts`):**
- Added `is_over_wfh_limit?: boolean` to `TeamMemberParticipation`.

**Frontend (`TeamParticipation.tsx`):**
- Renders a red "⚠ WFH over limit" pill below member name (and below "Team Lead" label if applicable) when `is_over_wfh_limit` is `true`.

**DI / `main.go`:**
- `wlRepo` passed as new argument to `NewMealService` (before `resolver`).

## Changelog

- Feature: Team Participation table now shows a red "WFH over limit" badge for members who have exceeded their monthly WFH allowance.
- Feature: Admins, Logistics, and Team Leads can call `GET /api/v1/work-location/team-monthly-report` to retrieve a monthly WFH usage report with per-member breakdown and rollup totals.

## How to Test

1. Ensure `PolicyConfig.MonthlyWFHAllowance` is set (default: 5).
2. Insert > 5 `work_locations` rows with `location = 'wfh'` for the current month for a test user.
3. `GET /api/v1/meals/all-teams-participation` — confirm that user's object includes `"is_over_wfh_limit": true`.
4. `GET /api/v1/work-location/team-monthly-report` with an admin/logistics and team-leads — confirm `over_limit_count`, `total_extra_days`, and per-member `extra_days` are correct.

## How QA Should Test

**Affected workflows:** Team Participation view, WFH report for Admins/Logistics/Team Leads.

**Checks:**
1. Log in as **Admin** → navigate to Team Participation → confirm over-limit members show the red badge; within-limit members do not.
2. Log in as **Team Lead** → same check, verify only own team is visible.
3. As a **regular employee**, attempt `GET /api/v1/work-location/team-monthly-report` → expect `401` or `403`.
4. Call the rollup endpoint without a `month` param → confirm it defaults to the current month.
5. Call with `?month=2026-01` → confirm historical data is returned correctly.
6. Confirm a member with exactly 5 WFH days (at the allowance, not over) shows `is_over_wfh_limit: false` and no badge.

## Rollback Plan

Revert this PR. No migrations were added, so no DB rollback is needed. The `wlRepo` argument added to `NewMealService` will cause a compile error in `main.go` after revert — remove it from the call site manually if a clean revert is not possible.

## Checklist

- [x] My code follows the project style guidelines
- [x] Code passes linting and type checks
- [x] All tests pass

## Note for Reviewer

Two areas worth extra attention:
- **`isOverWFHLimit` in `meal_service.go`** still uses per-user `CountWFHByUserAndMonth` (one query per member). For current team member size it's note a big problem as at most 10-20 calls per team. But future iteration could replace this with a batch query per team.