### PR TITLE
[PR-4] -- feat: core wiring for dynamodb and config

### DIFF
--- a/02-task-2-craftsbite/craftsbite_backend/internal/config/config.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/config/config.go
@@ -1,1 +1,94 @@
 package config
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+type ServerConfig struct {
+	Port int
+}
+
+type AWSConfig struct {
+	Region           string
+	DynamoDBEndpoint string
+}
+
+type TablesConfig struct {
+	UsersTable string
+	MealsTable string
+	WorkTable  string
+}
+
+type CutoffConfig struct {
+	CutoffTime string
+	Timezone   string
+}
+
+type DiscordConfig struct {
+	ApplicationID string
+	PublicKey     string
+	BotToken      string
+}
+
+type Config struct {
+	Server  ServerConfig
+	AWS     AWSConfig
+	Tables  TablesConfig
+	Cutoff  CutoffConfig
+	Discord DiscordConfig
+}
+
+func Load() (*Config, error) {
+	port := 8080
+	if p := os.Getenv("PORT"); p != "" {
+		parsed, err := strconv.Atoi(p)
+		if err != nil {
+			return nil, fmt.Errorf("invalid PORT value %q: %w", p, err)
+		}
+		port = parsed
+	}
+
+	cfg := &Config{
+		Server: ServerConfig{Port: port},
+		AWS: AWSConfig{
+			Region:           os.Getenv("AWS_REGION"),
+			DynamoDBEndpoint: os.Getenv("DYNAMODB_ENDPOINT"),
+		},
+		Tables: TablesConfig{
+			UsersTable: os.Getenv("USERS_TABLE"),
+			MealsTable: os.Getenv("MEALS_TABLE"),
+			WorkTable:  os.Getenv("WORK_TABLE"),
+		},
+		Cutoff: CutoffConfig{
+			CutoffTime: os.Getenv("CUTOFF_TIME"),
+			Timezone:   os.Getenv("TIMEZONE"),
+		},
+		Discord: DiscordConfig{
+			ApplicationID: os.Getenv("DISCORD_APPLICATION_ID"),
+			PublicKey:     os.Getenv("DISCORD_PUBLIC_KEY"),
+			BotToken:      os.Getenv("DISCORD_BOT_TOKEN"),
+		},
+	}
+
+	required := []struct {
+		name  string
+		value string
+	}{
+		{"USERS_TABLE", cfg.Tables.UsersTable},
+		{"MEALS_TABLE", cfg.Tables.MealsTable},
+		{"WORK_TABLE", cfg.Tables.WorkTable},
+		{"DISCORD_APPLICATION_ID", cfg.Discord.ApplicationID},
+		{"DISCORD_PUBLIC_KEY", cfg.Discord.PublicKey},
+		{"DISCORD_BOT_TOKEN", cfg.Discord.BotToken},
+	}
+
+	for _, r := range required {
+		if r.value == "" {
+			return nil, fmt.Errorf("%s is required but not set", r.name)
+		}
+	}
+
+	return cfg, nil
+}

--- a/02-task-2-craftsbite/craftsbite_backend/internal/config/config_test.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/config/config_test.go
@@ -1,0 +1,95 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func setEnv(t *testing.T, pairs map[string]string) {
+	t.Helper()
+	for k, v := range pairs {
+		t.Setenv(k, v)
+	}
+}
+
+func requiredEnv() map[string]string {
+	return map[string]string{
+		"USERS_TABLE":            "craftsbite-users",
+		"MEALS_TABLE":            "craftsbite-meals",
+		"WORK_TABLE":             "craftsbite-work",
+		"DISCORD_APPLICATION_ID": "app-id",
+		"DISCORD_PUBLIC_KEY":     "pub-key",
+		"DISCORD_BOT_TOKEN":      "bot-token",
+	}
+}
+
+func TestLoad_AllFieldsPopulated(t *testing.T) {
+	env := requiredEnv()
+	env["PORT"] = "9090"
+	env["AWS_REGION"] = "us-east-1"
+	env["DYNAMODB_ENDPOINT"] = "http://localhost:8000"
+	env["CUTOFF_TIME"] = "21:00"
+	env["TIMEZONE"] = "Asia/Dhaka"
+	setEnv(t, env)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Server.Port != 9090 {
+		t.Errorf("expected port 9090, got %d", cfg.Server.Port)
+	}
+	if cfg.AWS.Region != "us-east-1" {
+		t.Errorf("expected region us-east-1, got %s", cfg.AWS.Region)
+	}
+	if cfg.AWS.DynamoDBEndpoint != "http://localhost:8000" {
+		t.Errorf("unexpected DynamoDBEndpoint: %s", cfg.AWS.DynamoDBEndpoint)
+	}
+	if cfg.Tables.UsersTable != "craftsbite-users" {
+		t.Errorf("unexpected UsersTable: %s", cfg.Tables.UsersTable)
+	}
+	if cfg.Cutoff.CutoffTime != "21:00" {
+		t.Errorf("unexpected CutoffTime: %s", cfg.Cutoff.CutoffTime)
+	}
+	if cfg.Discord.BotToken != "bot-token" {
+		t.Errorf("unexpected BotToken: %s", cfg.Discord.BotToken)
+	}
+}
+
+func TestLoad_PortDefaultsTo8080(t *testing.T) {
+	setEnv(t, requiredEnv())
+	os.Unsetenv("PORT")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Server.Port != 8080 {
+		t.Errorf("expected default port 8080, got %d", cfg.Server.Port)
+	}
+}
+
+func TestLoad_MissingDiscordVar_ReturnsError(t *testing.T) {
+	env := requiredEnv()
+	delete(env, "DISCORD_BOT_TOKEN")
+	setEnv(t, env)
+	os.Unsetenv("DISCORD_BOT_TOKEN")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error when DISCORD_BOT_TOKEN is missing, got nil")
+	}
+}
+
+func TestLoad_MissingTableVar_ReturnsError(t *testing.T) {
+	env := requiredEnv()
+	delete(env, "MEALS_TABLE")
+	setEnv(t, env)
+	os.Unsetenv("MEALS_TABLE")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error when MEALS_TABLE is missing, got nil")
+	}
+}

--- a/02-task-2-craftsbite/craftsbite_backend/internal/dynamo/client.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/dynamo/client.go
@@ -1,1 +1,51 @@
 package dynamo
+
+import (
+	"context"
+	"os"
+	"sync"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+)
+
+var (
+	mu     sync.Mutex
+	client *dynamodb.Client
+)
+
+// GetClient returns a shared DynamoDB client.
+// If DYNAMODB_ENDPOINT is set, it overrides the endpoint for local development.
+// Otherwise the real AWS endpoint is resolved from the environment.
+func GetClient() *dynamodb.Client {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if client != nil {
+		return client
+	}
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background())
+	if err != nil {
+		panic("failed to load AWS config: " + err.Error())
+	}
+
+	opts := []func(*dynamodb.Options){}
+
+	if endpoint := os.Getenv("DYNAMODB_ENDPOINT"); endpoint != "" {
+		opts = append(opts, func(o *dynamodb.Options) {
+			o.BaseEndpoint = aws.String(endpoint)
+		})
+	}
+
+	client = dynamodb.NewFromConfig(cfg, opts...)
+	return client
+}
+
+// resetClient clears the cached client. For use in tests only.
+func resetClient() {
+	mu.Lock()
+	defer mu.Unlock()
+	client = nil
+}

--- a/02-task-2-craftsbite/craftsbite_backend/internal/dynamo/client.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/dynamo/client.go
@@ -2,6 +2,7 @@ package dynamo
 
 import (
 	"context"
+	"log"
 	"os"
 	"sync"
 
@@ -28,6 +29,8 @@ func GetClient() *dynamodb.Client {
 
 	cfg, err := awsconfig.LoadDefaultConfig(context.Background())
 	if err != nil {
+	    log.Printf("failed to load AWS config: %v", err)
+	    // In production, we want to fail hard if AWS config is not available.
 		panic("failed to load AWS config: " + err.Error())
 	}
 

--- a/02-task-2-craftsbite/craftsbite_backend/internal/dynamo/client_test.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/dynamo/client_test.go
@@ -1,0 +1,20 @@
+package dynamo
+
+import (
+	"testing"
+)
+
+func TestGetClient_WithLocalEndpoint_InitialisesWithoutError(t *testing.T) {
+	resetClient()
+	t.Cleanup(resetClient)
+
+	t.Setenv("DYNAMODB_ENDPOINT", "http://localhost:8000")
+	t.Setenv("AWS_REGION", "us-east-1")
+	t.Setenv("AWS_ACCESS_KEY_ID", "local")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "local")
+
+	c := GetClient()
+	if c == nil {
+		t.Fatal("expected non-nil DynamoDB client")
+	}
+}


### PR DESCRIPTION
Closes #58 

## Dependencies

- Sub-issue 1 PR (scaffold) must be merged first

## What does this PR do?

Implements all Go logic for the project foundation: environment-based config loading, DynamoDB client with local/AWS endpoint switching, Gin router with health and Discord placeholder routes, plain HTTP entry point, and tests for config and the DynamoDB client.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation

## What was changed

**`internal/config/config.go`**
- `Config` struct with five nested sub-structs: `ServerConfig`, `AWSConfig`, `TablesConfig`, `CutoffConfig`, `DiscordConfig`
- `Load()` reads all fields from env vars; `PORT` defaults to `8080` if unset; all table names and Discord credentials are required — returns an error if any are missing

**`internal/dynamo/client.go`**
- `GetClient() *dynamodb.Client` — mutex-guarded singleton (not `sync.Once`) so tests can call `resetClient()` to clear the cache between runs
- If `DYNAMODB_ENDPOINT` is set → uses it as the base endpoint (local mode); otherwise uses real AWS endpoint resolved from the SDK environment

**`internal/router/router.go`**
- `New(cfg *config.Config) *gin.Engine`
- `GET /health` → `200 {"status":"ok"}`
- `POST /discord/interact` → `501` placeholder (will be replaced in Phase 4)

**`cmd/main.go`**
- Loads `.env` via `godotenv`, calls `config.Load()`, initialises a zap production logger, starts Gin on `cfg.Server.Port`
- No `AWS_LAMBDA_RUNTIME_API` detection, no Lambda adapter import — the Lambda Web Adapter layer handles the bridge in production

**Tests**
- `internal/config/config_test.go` — 4 cases: all vars set, PORT default, missing Discord var, missing table var
- `internal/dynamo/client_test.go` — `GetClient()` with local endpoint set returns a non-nil client

## Changelog

None: not user visible

## How to Test

1. Copy `.env.example` to `.env` and fill in required fields (table names and Discord credentials)
2. `make run` — server should start on `:8080`
3. `curl http://localhost:8080/health` — should return `{"status":"ok"}`
4. `make test` — all tests should pass
5. `make build` — should produce `bootstrap` binary and `function.zip`

## How QA Should Test

**Affected workflows:** local server startup, health endpoint

- Run `make run` with a valid `.env` — server starts with no errors
- `curl http://localhost:8080/health` → `{"status":"ok"}`
- `curl -X POST http://localhost:8080/discord/interact` → `501`
- Remove `DISCORD_PUBLIC_KEY` from `.env` and re-run — server should fail to start with a clear error message
- Remove `PORT` from `.env` and re-run — server should start on `:8080` (default)

## Rollback Plan

Revert this PR. No production impact — no deployed infrastructure changed.

## Checklist

- [x] My code follows the project style guidelines
- [x] Code passes linting and type checks
- [x] All tests pass
- [x] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)

## Note for Reviewer

The DynamoDB client uses a mutex-guarded singleton instead of `sync.Once` specifically to allow `resetClient()` in tests — please check that this is acceptable. The `POST /discord/interact → 501` placeholder is intentional; the real handler lands in Phase 4.