### PR TITLE
doc: update technical doc to address updated GSI count

### DIFF
--- a/02-task-2-craftsbite/docs/technical_doc.md
+++ b/02-task-2-craftsbite/docs/technical_doc.md
@@ -138,7 +138,7 @@ DynamoDB tables follow a sparse key design. Each table uses a generic `PK` / `SK
 
 **craftsbite-work** — stores work location records per user per date.
 
-Each table uses two GSIs (`GSI1`, `GSI2`) for secondary access patterns. All GSIs use `PAY_PER_REQUEST` billing with full item projection.
+Each table uses a single GSI (GSI1) for secondary access patterns. All GSIs use PAY_PER_REQUEST billing with full item projection.
 
 ---
 
@@ -147,7 +147,7 @@ Each table uses two GSIs (`GSI1`, `GSI2`) for secondary access patterns. All GSI
 | Pattern                               | Table            | Method                          |
 | ------------------------------------- | ---------------- | ------------------------------- |
 | Resolve Discord user → internal user  | craftsbite-users | GetItem on `DISCORD#<id>`       |
-| List all active users                 | craftsbite-users | Query GSI2                      |
+| List all active users                 | craftsbite-users | Query GSI1                      |
 | Get team members                      | craftsbite-users | Query `TEAM#<id>` partition     |
 | Get user's team                       | craftsbite-users | Query GSI1                      |
 | Get day schedule                      | craftsbite-meals | GetItem on `SCHEDULE` partition |


### PR DESCRIPTION
Closes #42 

## Dependencies

- _(none needed)_

## What does this PR do?

Updates `docs/technical_doc.md` to reflect the current DynamoDB design — fixes the GSI count and the access pattern for listing active users.

## Type of Change

- [x] Documentation

## What was changed

Two outdated references in `docs/technical_doc.md`:

- **Section 8** — corrected GSI count from two (`GSI1`, `GSI2`) to one (`GSI1`) for `craftsbite-users`. The listing patterns (`ENTITY#USER`, `ENTITY#TEAM`) are now served by GSI1 via overloaded partition keys, not a separate GSI2.
- **Section 9** — updated "List all active users" access pattern from `Query GSI2` to `Query GSI1`.

## Changelog

None: not user visible

## How to Test

1. Read `docs/technical_doc.md` section 8 and verify it states one GSI per table
2. Read section 9 and verify "List all active users" references GSI1
3. Cross-reference against `docs/db-design-spec.md` section 6.1 — GSI table should show only GSI1 for `craftsbite-users`

## How QA Should Test

No runtime behaviour changed — documentation only. Verify the two corrected fields match the db design spec.

## Rollback Plan

No rollback needed — documentation only change.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have updated documentation (if applicable)

## Note for Reviewer

Just two field corrections.