### PR TITLE
Feat/dynamodb table seed

### DIFF
--- a/02-task-2-craftsbite/craftsbite_backend/cmd/main.go
+++ b/02-task-2-craftsbite/craftsbite_backend/cmd/main.go
@@ -1,1 +1,35 @@
 package main
+
+import (
+	"fmt"
+	"log"
+
+	"craftsbite-backend/internal/config"
+	"craftsbite-backend/internal/router"
+
+	"github.com/joho/godotenv"
+	"go.uber.org/zap"
+)
+
+func main() {
+	// .env is optional; ignored if not present (production uses injected env vars).
+	_ = godotenv.Load()
+
+	cfg, err := config.Load()
+	if err != nil {
+		log.Fatalf("failed to load config: %v", err)
+	}
+
+	logger, err := zap.NewProduction()
+	if err != nil {
+		log.Fatalf("failed to initialise logger: %v", err)
+	}
+	defer logger.Sync() //nolint:errcheck
+
+	r := router.New(cfg)
+
+	logger.Info("starting server", zap.Int("port", cfg.Server.Port))
+	if err := r.Run(fmt.Sprintf(":%d", cfg.Server.Port)); err != nil {
+		logger.Fatal("server failed", zap.Error(err))
+	}
+}

--- a/02-task-2-craftsbite/craftsbite_backend/internal/config/config.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/config/config.go
@@ -1,1 +1,94 @@
 package config
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+type ServerConfig struct {
+	Port int
+}
+
+type AWSConfig struct {
+	Region           string
+	DynamoDBEndpoint string
+}
+
+type TablesConfig struct {
+	UsersTable string
+	MealsTable string
+	WorkTable  string
+}
+
+type CutoffConfig struct {
+	CutoffTime string
+	Timezone   string
+}
+
+type DiscordConfig struct {
+	ApplicationID string
+	PublicKey     string
+	BotToken      string
+}
+
+type Config struct {
+	Server  ServerConfig
+	AWS     AWSConfig
+	Tables  TablesConfig
+	Cutoff  CutoffConfig
+	Discord DiscordConfig
+}
+
+func Load() (*Config, error) {
+	port := 8080
+	if p := os.Getenv("PORT"); p != "" {
+		parsed, err := strconv.Atoi(p)
+		if err != nil {
+			return nil, fmt.Errorf("invalid PORT value %q: %w", p, err)
+		}
+		port = parsed
+	}
+
+	cfg := &Config{
+		Server: ServerConfig{Port: port},
+		AWS: AWSConfig{
+			Region:           os.Getenv("AWS_REGION"),
+			DynamoDBEndpoint: os.Getenv("DYNAMODB_ENDPOINT"),
+		},
+		Tables: TablesConfig{
+			UsersTable: os.Getenv("USERS_TABLE"),
+			MealsTable: os.Getenv("MEALS_TABLE"),
+			WorkTable:  os.Getenv("WORK_TABLE"),
+		},
+		Cutoff: CutoffConfig{
+			CutoffTime: os.Getenv("CUTOFF_TIME"),
+			Timezone:   os.Getenv("TIMEZONE"),
+		},
+		Discord: DiscordConfig{
+			ApplicationID: os.Getenv("DISCORD_APPLICATION_ID"),
+			PublicKey:     os.Getenv("DISCORD_PUBLIC_KEY"),
+			BotToken:      os.Getenv("DISCORD_BOT_TOKEN"),
+		},
+	}
+
+	required := []struct {
+		name  string
+		value string
+	}{
+		{"USERS_TABLE", cfg.Tables.UsersTable},
+		{"MEALS_TABLE", cfg.Tables.MealsTable},
+		{"WORK_TABLE", cfg.Tables.WorkTable},
+		{"DISCORD_APPLICATION_ID", cfg.Discord.ApplicationID},
+		{"DISCORD_PUBLIC_KEY", cfg.Discord.PublicKey},
+		{"DISCORD_BOT_TOKEN", cfg.Discord.BotToken},
+	}
+
+	for _, r := range required {
+		if r.value == "" {
+			return nil, fmt.Errorf("%s is required but not set", r.name)
+		}
+	}
+
+	return cfg, nil
+}

--- a/02-task-2-craftsbite/craftsbite_backend/internal/config/config_test.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/config/config_test.go
@@ -1,0 +1,95 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func setEnv(t *testing.T, pairs map[string]string) {
+	t.Helper()
+	for k, v := range pairs {
+		t.Setenv(k, v)
+	}
+}
+
+func requiredEnv() map[string]string {
+	return map[string]string{
+		"USERS_TABLE":            "craftsbite-users",
+		"MEALS_TABLE":            "craftsbite-meals",
+		"WORK_TABLE":             "craftsbite-work",
+		"DISCORD_APPLICATION_ID": "app-id",
+		"DISCORD_PUBLIC_KEY":     "pub-key",
+		"DISCORD_BOT_TOKEN":      "bot-token",
+	}
+}
+
+func TestLoad_AllFieldsPopulated(t *testing.T) {
+	env := requiredEnv()
+	env["PORT"] = "9090"
+	env["AWS_REGION"] = "us-east-1"
+	env["DYNAMODB_ENDPOINT"] = "http://localhost:8000"
+	env["CUTOFF_TIME"] = "21:00"
+	env["TIMEZONE"] = "Asia/Dhaka"
+	setEnv(t, env)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Server.Port != 9090 {
+		t.Errorf("expected port 9090, got %d", cfg.Server.Port)
+	}
+	if cfg.AWS.Region != "us-east-1" {
+		t.Errorf("expected region us-east-1, got %s", cfg.AWS.Region)
+	}
+	if cfg.AWS.DynamoDBEndpoint != "http://localhost:8000" {
+		t.Errorf("unexpected DynamoDBEndpoint: %s", cfg.AWS.DynamoDBEndpoint)
+	}
+	if cfg.Tables.UsersTable != "craftsbite-users" {
+		t.Errorf("unexpected UsersTable: %s", cfg.Tables.UsersTable)
+	}
+	if cfg.Cutoff.CutoffTime != "21:00" {
+		t.Errorf("unexpected CutoffTime: %s", cfg.Cutoff.CutoffTime)
+	}
+	if cfg.Discord.BotToken != "bot-token" {
+		t.Errorf("unexpected BotToken: %s", cfg.Discord.BotToken)
+	}
+}
+
+func TestLoad_PortDefaultsTo8080(t *testing.T) {
+	setEnv(t, requiredEnv())
+	os.Unsetenv("PORT")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Server.Port != 8080 {
+		t.Errorf("expected default port 8080, got %d", cfg.Server.Port)
+	}
+}
+
+func TestLoad_MissingDiscordVar_ReturnsError(t *testing.T) {
+	env := requiredEnv()
+	delete(env, "DISCORD_BOT_TOKEN")
+	setEnv(t, env)
+	os.Unsetenv("DISCORD_BOT_TOKEN")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error when DISCORD_BOT_TOKEN is missing, got nil")
+	}
+}
+
+func TestLoad_MissingTableVar_ReturnsError(t *testing.T) {
+	env := requiredEnv()
+	delete(env, "MEALS_TABLE")
+	setEnv(t, env)
+	os.Unsetenv("MEALS_TABLE")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error when MEALS_TABLE is missing, got nil")
+	}
+}

--- a/02-task-2-craftsbite/craftsbite_backend/internal/dynamo/client.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/dynamo/client.go
@@ -1,1 +1,51 @@
 package dynamo
+
+import (
+	"context"
+	"os"
+	"sync"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+)
+
+var (
+	mu     sync.Mutex
+	client *dynamodb.Client
+)
+
+// GetClient returns a shared DynamoDB client.
+// If DYNAMODB_ENDPOINT is set, it overrides the endpoint for local development.
+// Otherwise the real AWS endpoint is resolved from the environment.
+func GetClient() *dynamodb.Client {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if client != nil {
+		return client
+	}
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background())
+	if err != nil {
+		panic("failed to load AWS config: " + err.Error())
+	}
+
+	opts := []func(*dynamodb.Options){}
+
+	if endpoint := os.Getenv("DYNAMODB_ENDPOINT"); endpoint != "" {
+		opts = append(opts, func(o *dynamodb.Options) {
+			o.BaseEndpoint = aws.String(endpoint)
+		})
+	}
+
+	client = dynamodb.NewFromConfig(cfg, opts...)
+	return client
+}
+
+// resetClient clears the cached client. For use in tests only.
+func resetClient() {
+	mu.Lock()
+	defer mu.Unlock()
+	client = nil
+}

--- a/02-task-2-craftsbite/craftsbite_backend/internal/dynamo/client.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/dynamo/client.go
@@ -2,6 +2,7 @@ package dynamo
 
 import (
 	"context"
+	"log"
 	"os"
 	"sync"
 
@@ -28,6 +29,8 @@ func GetClient() *dynamodb.Client {
 
 	cfg, err := awsconfig.LoadDefaultConfig(context.Background())
 	if err != nil {
+	    log.Printf("failed to load AWS config: %v", err)
+	    // In production, we want to fail hard if AWS config is not available.
 		panic("failed to load AWS config: " + err.Error())
 	}
 

--- a/02-task-2-craftsbite/craftsbite_backend/internal/dynamo/client_test.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/dynamo/client_test.go
@@ -1,0 +1,20 @@
+package dynamo
+
+import (
+	"testing"
+)
+
+func TestGetClient_WithLocalEndpoint_InitialisesWithoutError(t *testing.T) {
+	resetClient()
+	t.Cleanup(resetClient)
+
+	t.Setenv("DYNAMODB_ENDPOINT", "http://localhost:8000")
+	t.Setenv("AWS_REGION", "us-east-1")
+	t.Setenv("AWS_ACCESS_KEY_ID", "local")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "local")
+
+	c := GetClient()
+	if c == nil {
+		t.Fatal("expected non-nil DynamoDB client")
+	}
+}

--- a/02-task-2-craftsbite/craftsbite_backend/internal/router/router.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/router/router.go
@@ -1,1 +1,23 @@
 package router
+
+import (
+	"net/http"
+
+	"craftsbite-backend/internal/config"
+
+	"github.com/gin-gonic/gin"
+)
+
+func New(cfg *config.Config) *gin.Engine {
+	r := gin.Default()
+
+	r.GET("/health", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"status": "ok"})
+	})
+
+	r.POST("/discord/interact", func(c *gin.Context) {
+		c.Status(http.StatusNotImplemented)
+	})
+
+	return r
+}

--- a/02-task-2-craftsbite/craftsbite_backend/scripts/create_tables.go
+++ b/02-task-2-craftsbite/craftsbite_backend/scripts/create_tables.go
@@ -1,0 +1,92 @@
+//go:build ignore
+
+package main
+
+import (
+	"os"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+func usersTable() dynamodb.CreateTableInput {
+    return dynamodb.CreateTableInput{
+        TableName:   aws.String(os.Getenv("USERS_TABLE")),
+        BillingMode: types.BillingModePayPerRequest,
+        KeySchema: []types.KeySchemaElement{
+            {AttributeName: aws.String("PK"), KeyType: types.KeyTypeHash},
+            {AttributeName: aws.String("SK"), KeyType: types.KeyTypeRange},
+        },
+        AttributeDefinitions: []types.AttributeDefinition{
+            {AttributeName: aws.String("PK"),     AttributeType: types.ScalarAttributeTypeS},
+            {AttributeName: aws.String("SK"),     AttributeType: types.ScalarAttributeTypeS},
+            {AttributeName: aws.String("GSI1PK"), AttributeType: types.ScalarAttributeTypeS},
+            {AttributeName: aws.String("GSI1SK"), AttributeType: types.ScalarAttributeTypeS},
+        },
+        GlobalSecondaryIndexes: []types.GlobalSecondaryIndex{
+            {
+                IndexName: aws.String("GSI1"),
+                KeySchema: []types.KeySchemaElement{
+                    {AttributeName: aws.String("GSI1PK"), KeyType: types.KeyTypeHash},
+                    {AttributeName: aws.String("GSI1SK"), KeyType: types.KeyTypeRange},
+                },
+                Projection: &types.Projection{ProjectionType: types.ProjectionTypeAll},
+            },
+        },
+    }
+}
+
+func mealsTable() dynamodb.CreateTableInput {
+    return dynamodb.CreateTableInput{
+        TableName:   aws.String(os.Getenv("MEALS_TABLE")),
+        BillingMode: types.BillingModePayPerRequest,
+        KeySchema: []types.KeySchemaElement{
+            {AttributeName: aws.String("PK"), KeyType: types.KeyTypeHash},
+            {AttributeName: aws.String("SK"), KeyType: types.KeyTypeRange},
+        },
+        AttributeDefinitions: []types.AttributeDefinition{
+            {AttributeName: aws.String("PK"),     AttributeType: types.ScalarAttributeTypeS},
+            {AttributeName: aws.String("SK"),     AttributeType: types.ScalarAttributeTypeS},
+            {AttributeName: aws.String("GSI1PK"), AttributeType: types.ScalarAttributeTypeS},
+            {AttributeName: aws.String("GSI1SK"), AttributeType: types.ScalarAttributeTypeS},
+        },
+        GlobalSecondaryIndexes: []types.GlobalSecondaryIndex{
+            {
+                IndexName: aws.String("GSI1"),
+                KeySchema: []types.KeySchemaElement{
+                    {AttributeName: aws.String("GSI1PK"), KeyType: types.KeyTypeHash},
+                    {AttributeName: aws.String("GSI1SK"), KeyType: types.KeyTypeRange},
+                },
+                Projection: &types.Projection{ProjectionType: types.ProjectionTypeAll},
+            },
+        },
+    }
+}
+
+func workTable() dynamodb.CreateTableInput {
+    return dynamodb.CreateTableInput{
+        TableName:   aws.String(os.Getenv("WORK_TABLE")),
+        BillingMode: types.BillingModePayPerRequest,
+        KeySchema: []types.KeySchemaElement{
+            {AttributeName: aws.String("PK"), KeyType: types.KeyTypeHash},
+            {AttributeName: aws.String("SK"), KeyType: types.KeyTypeRange},
+        },
+        AttributeDefinitions: []types.AttributeDefinition{
+            {AttributeName: aws.String("PK"),     AttributeType: types.ScalarAttributeTypeS},
+            {AttributeName: aws.String("SK"),     AttributeType: types.ScalarAttributeTypeS},
+            {AttributeName: aws.String("GSI1PK"), AttributeType: types.ScalarAttributeTypeS},
+            {AttributeName: aws.String("GSI1SK"), AttributeType: types.ScalarAttributeTypeS},
+        },
+        GlobalSecondaryIndexes: []types.GlobalSecondaryIndex{
+            {
+                IndexName: aws.String("GSI1"),
+                KeySchema: []types.KeySchemaElement{
+                    {AttributeName: aws.String("GSI1PK"), KeyType: types.KeyTypeHash},
+                    {AttributeName: aws.String("GSI1SK"), KeyType: types.KeyTypeRange},
+                },
+                Projection: &types.Projection{ProjectionType: types.ProjectionTypeAll},
+            },
+        },
+    }
+}

--- a/02-task-2-craftsbite/craftsbite_backend/scripts/create_tables.go
+++ b/02-task-2-craftsbite/craftsbite_backend/scripts/create_tables.go
@@ -3,12 +3,46 @@
 package main
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
 	"os"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/joho/godotenv"
+
+	"craftsbite-backend/internal/dynamo"
 )
+
+func main() {
+    _ = godotenv.Load()
+
+    client := dynamo.GetClient()
+    ctx := context.Background()
+
+    tables := []dynamodb.CreateTableInput{
+        usersTable(),
+        mealsTable(),
+        workTable(),
+    }
+
+    for _, input := range tables {
+        _, err := client.CreateTable(ctx, &input)
+        if err != nil {
+            // Ignore "already exists" errors so the script is safe to re-run
+            var resErr *types.ResourceInUseException
+            if errors.As(err, &resErr) {
+                fmt.Printf("table %s already exists, skipping\n", *input.TableName)
+                continue
+            }
+            log.Fatalf("failed to create table %s: %v", *input.TableName, err)
+        }
+        fmt.Printf("created table: %s\n", *input.TableName)
+    }
+}
 
 func usersTable() dynamodb.CreateTableInput {
     return dynamodb.CreateTableInput{

--- a/02-task-2-craftsbite/craftsbite_backend/scripts/seed_tables.go
+++ b/02-task-2-craftsbite/craftsbite_backend/scripts/seed_tables.go
@@ -1,14 +1,131 @@
+//go:build ignore
+
 package main
 
 import (
 	"context"
+	"fmt"
+	"log"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/joho/godotenv"
+
+	"craftsbite-backend/internal/dynamo"
 )
 
+const (
+	// Teams
+	teamSagaID  = "aaaaaaaa-0000-0000-0000-000000000001"
+	teamMimirID = "bbbbbbbb-0000-0000-0000-000000000002"
+
+	// Team leads
+	userRafiqID  = "cccccccc-0000-0000-0000-000000000001" // team_lead — SAGA
+	userNusratID = "dddddddd-0000-0000-0000-000000000002" // team_lead — MIMIR
+
+	// SAGA members
+	userArifID    = "eeeeeeee-0000-0000-0000-000000000003" // employee
+	userSumaiyaID = "ffffffff-0000-0000-0000-000000000004" // employee
+
+	// MIMIR members
+	userTanvirID = "00000000-aaaa-0000-0000-000000000005" // employee
+	userFatemaID = "00000000-bbbb-0000-0000-000000000006" // employee
+
+	// Org-level roles
+	userMahbubID  = "00000000-cccc-0000-0000-000000000007" // admin
+	userSharminID = "00000000-dddd-0000-0000-000000000008" // logistics
+
+	// Discord IDs
+	discordRafiq   = "111111111111111111"
+	discordNusrat  = "222222222222222222"
+	discordArif    = "333333333333333333"
+	discordSumaiya = "444444444444444444"
+	discordTanvir  = "555555555555555555"
+	discordFatema  = "666666666666666666"
+	discordMahbub  = "777777777777777777"
+	discordSharmin = "888888888888888888"
+
+	usersTable = "craftsbite-users"
+)
+
+func main() {
+	_ = godotenv.Load()
+
+	client := dynamo.GetClient()
+	ctx := context.Background()
+
+	items := []map[string]types.AttributeValue{
+		// --- Teams ---
+		teamItem(teamSagaID, "SAGA", userRafiqID, true),
+		teamListingItem(teamSagaID, true),
+		teamItem(teamMimirID, "MIMIR", userNusratID, true),
+		teamListingItem(teamMimirID, true),
+
+		// --- Users ---
+
+		// Team leads
+		userProfileItem(userRafiqID, "rafiq@craftsbite.com", "Rafiq Hassan", "team_lead", true),
+		userListingItem(userRafiqID, "team_lead", true),
+		userProfileItem(userNusratID, "nusrat@craftsbite.com", "Nusrat Jahan", "team_lead", true),
+		userListingItem(userNusratID, "team_lead", true),
+
+		// SAGA employees
+		userProfileItem(userArifID, "arif@craftsbite.com", "Arif Hossain", "employee", true),
+		userListingItem(userArifID, "employee", true),
+		userProfileItem(userSumaiyaID, "sumaiya@craftsbite.com", "Sumaiya Begum", "employee", true),
+		userListingItem(userSumaiyaID, "employee", true),
+
+		// MIMIR employees
+		userProfileItem(userTanvirID, "tanvir@craftsbite.com", "Tanvir Ahmed", "employee", true),
+		userListingItem(userTanvirID, "employee", true),
+		userProfileItem(userFatemaID, "fatema@craftsbite.com", "Fatema Khatun", "employee", true),
+		userListingItem(userFatemaID, "employee", true),
+
+		// Admin
+		userProfileItem(userMahbubID, "mahbub@craftsbite.com", "Mahbub Alam", "admin", true),
+		userListingItem(userMahbubID, "admin", true),
+
+		// Logistics
+		userProfileItem(userSharminID, "sharmin@craftsbite.com", "Sharmin Akter", "logistics", true),
+		userListingItem(userSharminID, "logistics", true),
+
+		// --- TeamMember edges ---
+
+		// SAGA: Rafiq (lead) + Arif + Sumaiya
+		teamMemberItem(teamSagaID, userRafiqID),
+		teamMemberItem(teamSagaID, userArifID),
+		teamMemberItem(teamSagaID, userSumaiyaID),
+
+		// MIMIR: Nusrat (lead) + Tanvir + Fatema
+		teamMemberItem(teamMimirID, userNusratID),
+		teamMemberItem(teamMimirID, userTanvirID),
+		teamMemberItem(teamMimirID, userFatemaID),
+
+		// --- Discord lookups ---
+		discordLookupItem(discordRafiq, userRafiqID, "team_lead"),
+		discordLookupItem(discordNusrat, userNusratID, "team_lead"),
+		discordLookupItem(discordArif, userArifID, "employee"),
+		discordLookupItem(discordSumaiya, userSumaiyaID, "employee"),
+		discordLookupItem(discordTanvir, userTanvirID, "employee"),
+		discordLookupItem(discordFatema, userFatemaID, "employee"),
+		discordLookupItem(discordMahbub, userMahbubID, "admin"),
+		discordLookupItem(discordSharmin, userSharminID, "logistics"),
+	}
+
+	for _, item := range items {
+		if err := putItem(ctx, client, usersTable, item); err != nil {
+			log.Fatalf("failed to put item %v: %v", item["PK"], err)
+		}
+	}
+
+	fmt.Println("seed complete")
+	printLookupTable()
+}
+
 // --- Item builders ---
+
 func teamItem(id, name, leadID string, active bool) map[string]types.AttributeValue {
 	return map[string]types.AttributeValue{
 		"PK":         &types.AttributeValueMemberS{Value: "TEAM#" + id},
@@ -106,4 +223,27 @@ func boolPrefix(active bool) string {
 		return "true"
 	}
 	return "false"
+}
+
+func printLookupTable() {
+	fmt.Println("\n=== Discord ID → User Lookup ===")
+	fmt.Printf("%-22s %-12s %-20s %-10s %s\n", "Discord ID", "Role", "Name", "Team", "User ID")
+	fmt.Println(strings.Repeat("-", 88))
+
+	rows := []struct {
+		discord, role, name, team, userID string
+	}{
+		{discordRafiq,   "team_lead", "Rafiq Hassan",  "SAGA",  userRafiqID},
+		{discordArif,    "employee",  "Arif Hossain",  "SAGA",  userArifID},
+		{discordSumaiya, "employee",  "Sumaiya Begum", "SAGA",  userSumaiyaID},
+		{discordNusrat,  "team_lead", "Nusrat Jahan",  "MIMIR", userNusratID},
+		{discordTanvir,  "employee",  "Tanvir Ahmed",  "MIMIR", userTanvirID},
+		{discordFatema,  "employee",  "Fatema Khatun", "MIMIR", userFatemaID},
+		{discordMahbub,  "admin",     "Mahbub Alam",   "—",     userMahbubID},
+		{discordSharmin, "logistics", "Sharmin Akter", "—",     userSharminID},
+	}
+
+	for _, r := range rows {
+		fmt.Printf("%-22s %-12s %-20s %-10s %s\n", r.discord, r.role, r.name, r.team, r.userID)
+	}
 }

--- a/02-task-2-craftsbite/craftsbite_backend/scripts/seed_tables.go
+++ b/02-task-2-craftsbite/craftsbite_backend/scripts/seed_tables.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+// --- Item builders ---
+func teamItem(id, name, leadID string, active bool) map[string]types.AttributeValue {
+	return map[string]types.AttributeValue{
+		"PK":         &types.AttributeValueMemberS{Value: "TEAM#" + id},
+		"SK":         &types.AttributeValueMemberS{Value: "#METADATA"},
+		"entityType": &types.AttributeValueMemberS{Value: "TEAM"},
+		"id":         &types.AttributeValueMemberS{Value: id},
+		"name":       &types.AttributeValueMemberS{Value: name},
+		"teamLeadID": &types.AttributeValueMemberS{Value: leadID},
+		"active":     &types.AttributeValueMemberBOOL{Value: active},
+		// GSI1 — team lead lookup
+		"GSI1PK": &types.AttributeValueMemberS{Value: "TEAMLEAD#" + leadID},
+		"GSI1SK": &types.AttributeValueMemberS{Value: "TEAM#" + id},
+	}
+}
+
+func teamListingItem(id string, active bool) map[string]types.AttributeValue {
+	activeStr := boolPrefix(active)
+	return map[string]types.AttributeValue{
+		"PK":         &types.AttributeValueMemberS{Value: "TEAM#" + id},
+		"SK":         &types.AttributeValueMemberS{Value: "#LISTING"},
+		"entityType": &types.AttributeValueMemberS{Value: "TEAM_LISTING"},
+		"id":         &types.AttributeValueMemberS{Value: id},
+		// GSI1 — entity listing
+		"GSI1PK": &types.AttributeValueMemberS{Value: "ENTITY#TEAM"},
+		"GSI1SK": &types.AttributeValueMemberS{Value: activeStr + "#TEAM#" + id},
+	}
+}
+
+func userProfileItem(id, email, name, role string, active bool) map[string]types.AttributeValue {
+	return map[string]types.AttributeValue{
+		"PK":         &types.AttributeValueMemberS{Value: "USER#" + id},
+		"SK":         &types.AttributeValueMemberS{Value: "#PROFILE"},
+		"entityType": &types.AttributeValueMemberS{Value: "USER"},
+		"id":         &types.AttributeValueMemberS{Value: id},
+		"email":      &types.AttributeValueMemberS{Value: email},
+		"name":       &types.AttributeValueMemberS{Value: name},
+		"role":       &types.AttributeValueMemberS{Value: role},
+		"active":     &types.AttributeValueMemberBOOL{Value: active},
+		// GSI1 — email lookup
+		"GSI1PK": &types.AttributeValueMemberS{Value: "EMAIL#" + email},
+		"GSI1SK": &types.AttributeValueMemberS{Value: "USER#" + id},
+	}
+}
+
+func userListingItem(id, role string, active bool) map[string]types.AttributeValue {
+	activeStr := boolPrefix(active)
+	return map[string]types.AttributeValue{
+		"PK":         &types.AttributeValueMemberS{Value: "USER#" + id},
+		"SK":         &types.AttributeValueMemberS{Value: "#LISTING"},
+		"entityType": &types.AttributeValueMemberS{Value: "USER_LISTING"},
+		"id":         &types.AttributeValueMemberS{Value: id},
+		"role":       &types.AttributeValueMemberS{Value: role},
+		// GSI1 — entity listing
+		"GSI1PK": &types.AttributeValueMemberS{Value: "ENTITY#USER"},
+		"GSI1SK": &types.AttributeValueMemberS{Value: activeStr + "#USER#" + id},
+	}
+}
+
+func teamMemberItem(teamID, userID string) map[string]types.AttributeValue {
+	return map[string]types.AttributeValue{
+		"PK":         &types.AttributeValueMemberS{Value: "TEAM#" + teamID},
+		"SK":         &types.AttributeValueMemberS{Value: "MEMBER#" + userID},
+		"entityType": &types.AttributeValueMemberS{Value: "TEAM_MEMBER"},
+		"teamID":     &types.AttributeValueMemberS{Value: teamID},
+		"userID":     &types.AttributeValueMemberS{Value: userID},
+		// GSI1 — user → team reverse lookup
+		"GSI1PK": &types.AttributeValueMemberS{Value: "USER_TEAMS#" + userID},
+		"GSI1SK": &types.AttributeValueMemberS{Value: "TEAM#" + teamID},
+	}
+}
+
+func discordLookupItem(discordID, userID, role string) map[string]types.AttributeValue {
+	return map[string]types.AttributeValue{
+		"PK":         &types.AttributeValueMemberS{Value: "DISCORD#" + discordID},
+		"SK":         &types.AttributeValueMemberS{Value: "#LOOKUP"},
+		"entityType": &types.AttributeValueMemberS{Value: "DISCORD_LOOKUP"},
+		"discordId":  &types.AttributeValueMemberS{Value: discordID},
+		"userID":     &types.AttributeValueMemberS{Value: userID},
+		"role":       &types.AttributeValueMemberS{Value: role},
+	}
+}
+
+// --- Helpers ---
+
+func putItem(ctx context.Context, client *dynamodb.Client, table string, item map[string]types.AttributeValue) error {
+	_, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String(table),
+		Item:      item,
+	})
+	return err
+}
+
+func boolPrefix(active bool) string {
+	if active {
+		return "true"
+	}
+	return "false"
+}


### PR DESCRIPTION
Closes #42 

## Dependencies

- PR 1 (docs) should be merged first.

## What does this PR do?

Adds `scripts/create_tables.go` and `scripts/seed.go` — local development scripts to create all 3 DynamoDB tables and populate `craftsbite-users` with enough data to exercise every role and access pattern without touching AWS.

## Type of Change

- [x] New feature

## What was changed

**`scripts/create_tables.go`**
- Creates `craftsbite-users`, `craftsbite-meals`, and `craftsbite-work` on local DynamoDB
- Each table uses `PAY_PER_REQUEST` billing with `PK`/`SK` keys and a single GSI1 (`GSI1PK`/`GSI1SK`, ALL projection)
- Safe to re-run — skips tables that already exist via `ResourceInUseException` check
- Both scripts carry a `//go:build ignore` build tag so they are never compiled as part of the main binary

**`scripts/seed.go`**
- Seeds `craftsbite-users` with 2 teams (SAGA, MIMIR), 2 team leads, 4 employees, 1 admin, 1 logistics user — 8 users total
- Each User and Team writes two items: a profile/metadata item (GSI1 direct lookup) and a listing item (GSI1 `ENTITY#USER` / `ENTITY#TEAM` partition)
- TeamMember edges written for both teams (3 members each including the lead)
- DiscordLookup item written per user (`PK=DISCORD#<id>`, `SK=#LOOKUP`) with `userID` and `role` denormalized for single-read identity resolution
- Prints a Discord ID → user lookup table to stdout on completion

Key shapes match `docs/db-design-spec.md` exactly.

## Changelog

None: not user visible — local development tooling only

## How to Test
```bash
# Start local DynamoDB
docker-compose up -d

# Create tables
go run ./scripts/create_tables.go

# Verify tables exist
aws dynamodb list-tables --endpoint-url http://localhost:8000
# Expected: craftsbite-users, craftsbite-meals, craftsbite-work

# Seed data
go run ./scripts/seed.go
# Expected: "seed complete" + Discord lookup table printed to stdout

# Spot-check a Discord lookup item
aws dynamodb get-item \
  --endpoint-url http://localhost:8000 \
  --table-name craftsbite-users \
  --key '{"PK": {"S": "DISCORD#111111111111111111"}, "SK": {"S": "#LOOKUP"}}'
# Expected: item with userID, role: team_lead

# Spot-check a listing item
aws dynamodb query \
  --endpoint-url http://localhost:8000 \
  --table-name craftsbite-users \
  --index-name GSI1 \
  --key-condition-expression "GSI1PK = :pk AND begins_with(GSI1SK, :prefix)" \
  --expression-attribute-values '{":pk": {"S": "ENTITY#USER"}, ":prefix": {"S": "true#"}}'
# Expected: 8 active user listing items
```

## How QA Should Test

These are local dev scripts with no production impact. QA should:

1. Follow the steps above in a fresh local environment after `docker-compose up -d`
2. Confirm all 3 table names are returned by `list-tables`
3. Confirm `seed.go` completes without error and prints the lookup table
4. Confirm at least one item per entity type is readable with the correct `PK`/`SK` shape using `get-item`

## Rollback Plan

No rollback needed — local development tooling only, not deployed to Lambda.

## Checklist

- [x] My code follows the project style guidelines
- [x] All tests pass
- [x] I have updated documentation (if applicable)

## Note for Reviewer

The dual-item pattern for Users and Teams (profile item + listing item) is intentional — a single DynamoDB item can only carry one `GSI1PK` value, so the email lookup entry and the `ENTITY#USER` listing entry must be separate items.