### PR TITLE
[PR-8] feat: implement /meal slash command Lambda

### DIFF
--- a/02-task-2-craftsbite/craftsbite_backend/cmd/self/main.go
+++ b/02-task-2-craftsbite/craftsbite_backend/cmd/self/main.go
@@ -1,12 +1,163 @@
 package main
 
-import "github.com/aws/aws-lambda-go/lambda"
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	appconfig "github.com/sayad-ika/craftsbite/internal/config"
+	"github.com/sayad-ika/craftsbite/internal/discord"
+	"github.com/sayad-ika/craftsbite/internal/dynamo"
+	"github.com/sayad-ika/craftsbite/internal/services"
+)
+
+type CommandEvent struct {
+	UserID           string                 `json:"userID"`
+	Role             string                 `json:"role"`
+	DiscordID        string                 `json:"discordId"`
+	CommandName      string                 `json:"commandName"`
+	Options          map[string]interface{} `json:"options"`
+	InteractionToken string                 `json:"interactionToken"`
+	ApplicationID    string                 `json:"applicationId"`
+}
+
+var validMealOptions = map[string]bool{
+	"lunch":           true,
+	"snacks":          true,
+	"event_dinner":    true,
+	"optional_dinner": true,
+	"all":             true,
+}
+
+var (
+	cfgOnce sync.Once
+	cfg     *appconfig.Config
+)
+
+func getConfig() *appconfig.Config {
+	cfgOnce.Do(func() {
+		cfg = appconfig.MustLoad()
+	})
+	return cfg
+}
+
+func handler(ctx context.Context, event CommandEvent) error {
+	c := getConfig()
+	client := dynamo.GetClient(c)
+
+	var replyContent string
+
+	switch event.CommandName {
+	case "meal":
+		replyContent = handleMeal(ctx, client, c.DynamoDBTable, event)
+	case "location":
+		replyContent = "This feature is coming soon."
+	case "status":
+		replyContent = "This feature is coming soon."
+	default:
+		replyContent = fmt.Sprintf("Unknown command: /%s", event.CommandName)
+	}
+
+	return discord.SendFollowup(event.ApplicationID, event.InteractionToken, replyContent)
+}
+
+func handleMeal(ctx context.Context, client *dynamodb.Client, table string, event CommandEvent) string {
+	date, ok := optString(event.Options, "date")
+	if !ok || date == "" {
+		return "Please provide a date. Example: `/meal date:2026-03-10 status:out`"
+	}
+
+	statusStr, ok := optString(event.Options, "status")
+	if !ok || (statusStr != "in" && statusStr != "out") {
+		return "Please specify status as `in` or `out`."
+	}
+	isParticipating := statusStr == "in"
+
+	mealType, _ := optString(event.Options, "meal")
+	if mealType == "" {
+		mealType = "all"
+	}
+	if !validMealOptions[mealType] {
+		return fmt.Sprintf("`%s` is not a valid meal type. Choose from: lunch, snacks, event_dinner, optional_dinner, all.", mealType)
+	}
+
+	statuses, err := services.UpdateParticipation(ctx, client, table, event.UserID, date, mealType, isParticipating)
+	if err != nil {
+		return mealErrorReply(err, date)
+	}
+
+	return formatMealStatus(date, statuses)
+}
+
+func optString(opts map[string]interface{}, key string) (string, bool) {
+	v, ok := opts[key]
+	if !ok {
+		return "", false
+	}
+	s, ok := v.(string)
+	return s, ok
+}
+
+func mealErrorReply(err error, date string) string {
+	switch err {
+	case services.ErrPastDate:
+		return "Cannot update participation for a past date."
+	case services.ErrCutoffPassed:
+		return fmt.Sprintf("Updates for %s are closed. Cutoff was %s at 9:00 PM.", date, prevDay(date))
+	case services.ErrTooFarAhead:
+		return fmt.Sprintf("Cannot update participation for %s — that's more than 7 days away.", date)
+	case services.ErrDayClosed:
+		return fmt.Sprintf("Office is closed on %s — no meals are available.", date)
+	case services.ErrNoMeals:
+		return fmt.Sprintf("No meals are configured for %s.", date)
+	case services.ErrMealUnavailable:
+		return fmt.Sprintf("That meal is not available on %s.", date)
+	default:
+		return "Something went wrong. Please try again later."
+	}
+}
+
+func prevDay(targetDate string) string {
+	t, err := time.Parse("2006-01-02", targetDate)
+	if err != nil {
+		return targetDate + " (previous day)"
+	}
+	return t.AddDate(0, 0, -1).Format("2006-01-02")
+}
+
+func formatMealStatus(date string, statuses []services.ResolvedStatus) string {
+	if len(statuses) == 0 {
+		return fmt.Sprintf("No meals are available on %s.", date)
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Updated! Meal status for %s:", date)
+	for _, s := range statuses {
+		icon := "✗"
+		if s.Status == "opted_in" {
+			icon = "✓"
+		} else if s.Status == "unavailable" {
+			icon = "—"
+		}
+		fmt.Fprintf(&sb, "  %s %s", displayMealName(s.MealType), icon)
+	}
+	return sb.String()
+}
+
+func displayMealName(s string) string {
+	words := strings.Split(strings.ReplaceAll(s, "_", " "), " ")
+	for i, w := range words {
+		if len(w) > 0 {
+			words[i] = strings.ToUpper(w[:1]) + w[1:]
+		}
+	}
+	return strings.Join(words, " ")
+}
 
 func main() {
 	lambda.Start(handler)
-}
-
-func handler() error {
-	// TODO: Self Cmd slash command
-	return nil
 }

--- a/02-task-2-craftsbite/craftsbite_backend/internal/discord/followup.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/discord/followup.go
@@ -12,11 +12,11 @@ import (
 var followupClient = &http.Client{Timeout: 5 * time.Second}
 
 func SendFollowup(applicationID, token, content string) error {
-    url := fmt.Sprintf(
-        "https://discord.com/api/v10/webhooks/%s/%s",
-        applicationID,
-        token,
-    )
+	url := fmt.Sprintf(
+		"https://discord.com/api/v10/webhooks/%s/%s/messages/@original",
+		applicationID,
+		token,
+	)
 
 	payload := map[string]interface{}{
 		"content": content,
@@ -26,22 +26,22 @@ func SendFollowup(applicationID, token, content string) error {
 		return fmt.Errorf("discord: failed to marshal followup payload: %w", err)
 	}
 
-    req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
-    if err != nil {
-        return fmt.Errorf("discord: failed to build followup request: %w", err)
-    }
-    req.Header.Set("Content-Type", "application/json")
+	req, err := http.NewRequest(http.MethodPatch, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("discord: failed to build followup request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
 
-    resp, err := followupClient.Do(req)
-    if err != nil {
-        return fmt.Errorf("discord: followup HTTP call failed: %w", err)
-    }
-    defer resp.Body.Close()
+	resp, err := followupClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("discord: followup HTTP call failed: %w", err)
+	}
+	defer resp.Body.Close()
 
-    respBody, _ := io.ReadAll(resp.Body)
-    if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-        return fmt.Errorf("discord: followup returned non-2xx status %d: %s", resp.StatusCode, respBody)
-    }
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("discord: followup returned non-2xx status %d: %s", resp.StatusCode, respBody)
+	}
 
-    return nil
+	return nil
 }

--- a/02-task-2-craftsbite/craftsbite_backend/internal/repository/day.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/repository/day.go
@@ -1,0 +1,70 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+
+
+func GetDay(ctx context.Context, client *dynamodb.Client, table, date string) (*DaySchedule, error) {
+	out, err := client.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName: aws.String(table),
+		Key: map[string]types.AttributeValue{
+			"PK": &types.AttributeValueMemberS{Value: "DAY#" + date},
+			"SK": &types.AttributeValueMemberS{Value: "METADATA"},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("repository: GetDay: %w", err)
+	}
+	if out.Item == nil {
+		return nil, nil
+	}
+
+	var item dayScheduleItem
+	if err := attributevalue.UnmarshalMap(out.Item, &item); err != nil {
+		return nil, fmt.Errorf("repository: GetDay unmarshal: %w", err)
+	}
+
+	createdAt, _ := time.Parse(rfc3339, item.CreatedAt)
+	updatedAt, _ := time.Parse(rfc3339, item.UpdatedAt)
+
+	return &DaySchedule{
+		Date:           item.Date,
+		DayStatus:      item.DayStatus,
+		AvailableMeals: item.AvailableMeals,
+		Reason:         item.Reason,
+		CreatedBy:      item.CreatedBy,
+		CreatedAt:      createdAt,
+		UpdatedAt:      updatedAt,
+	}, nil
+}
+
+func GetAvailableMeals(ctx context.Context, client *dynamodb.Client, table, date string) ([]string, error) {
+	out, err := client.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName: aws.String(table),
+		Key: map[string]types.AttributeValue{
+			"PK": &types.AttributeValueMemberS{Value: "DAY#" + date},
+			"SK": &types.AttributeValueMemberS{Value: "MEALS"},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("repository: GetAvailableMeals: %w", err)
+	}
+	if out.Item == nil {
+		return nil, nil
+	}
+
+	var item dayMealsItem
+	if err := attributevalue.UnmarshalMap(out.Item, &item); err != nil {
+		return nil, fmt.Errorf("repository: GetAvailableMeals unmarshal: %w", err)
+	}
+	return item.Meals, nil
+}

--- a/02-task-2-craftsbite/craftsbite_backend/internal/repository/meal_participation.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/repository/meal_participation.go
@@ -1,0 +1,111 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+func GetParticipation(ctx context.Context, client *dynamodb.Client, table, userID, date, mealType string) (*MealParticipation, error) {
+	out, err := client.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName: aws.String(table),
+		Key: map[string]types.AttributeValue{
+			"PK": &types.AttributeValueMemberS{Value: "USER#" + userID},
+			"SK": &types.AttributeValueMemberS{Value: "MEAL#" + date + "#" + mealType},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("repository: GetParticipation: %w", err)
+	}
+	if out.Item == nil {
+		return nil, nil
+	}
+
+	var item mealItem
+	if err := attributevalue.UnmarshalMap(out.Item, &item); err != nil {
+		return nil, fmt.Errorf("repository: GetParticipation unmarshal: %w", err)
+	}
+
+	return mealItemToParticipation(item), nil
+}
+
+func GetParticipationsByUserDate(ctx context.Context, client *dynamodb.Client, table, userID, date string) ([]MealParticipation, error) {
+	prefix := "MEAL#" + date + "#"
+	out, err := client.Query(ctx, &dynamodb.QueryInput{
+		TableName:              aws.String(table),
+		KeyConditionExpression: aws.String("PK = :pk AND begins_with(SK, :prefix)"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":pk":     &types.AttributeValueMemberS{Value: "USER#" + userID},
+			":prefix": &types.AttributeValueMemberS{Value: prefix},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("repository: GetParticipationsByUserDate: %w", err)
+	}
+
+	results := make([]MealParticipation, 0, len(out.Items))
+	for _, rawItem := range out.Items {
+		var item mealItem
+		if err := attributevalue.UnmarshalMap(rawItem, &item); err != nil {
+			return nil, fmt.Errorf("repository: GetParticipationsByUserDate unmarshal: %w", err)
+		}
+		results = append(results, *mealItemToParticipation(item))
+	}
+	return results, nil
+}
+
+func UpsertParticipation(ctx context.Context, client *dynamodb.Client, table string, p MealParticipation) error {
+	now := time.Now().UTC().Format(rfc3339)
+
+	createdAt := now
+	if !p.CreatedAt.IsZero() {
+		createdAt = p.CreatedAt.UTC().Format(rfc3339)
+	}
+
+	item, err := attributevalue.MarshalMap(mealItem{
+		PK:              "USER#" + p.UserID,
+		SK:              "MEAL#" + p.Date + "#" + p.MealType,
+		GSI1PK:          p.Date,
+		GSI1SK:          "MEAL#USER#" + p.UserID,
+		UserID:          p.UserID,
+		Date:            p.Date,
+		MealType:        p.MealType,
+		IsParticipating: p.IsParticipating,
+		OverrideBy:      p.OverrideBy,
+		OverrideReason:  p.OverrideReason,
+		CreatedAt:       createdAt,
+		UpdatedAt:       now,
+	})
+	if err != nil {
+		return fmt.Errorf("repository: UpsertParticipation marshal: %w", err)
+	}
+
+	_, err = client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String(table),
+		Item:      item,
+	})
+	if err != nil {
+		return fmt.Errorf("repository: UpsertParticipation: %w", err)
+	}
+	return nil
+}
+
+func mealItemToParticipation(item mealItem) *MealParticipation {
+	createdAt, _ := time.Parse(rfc3339, item.CreatedAt)
+	updatedAt, _ := time.Parse(rfc3339, item.UpdatedAt)
+	return &MealParticipation{
+		UserID:          item.UserID,
+		Date:            item.Date,
+		MealType:        item.MealType,
+		IsParticipating: item.IsParticipating,
+		OverrideBy:      item.OverrideBy,
+		OverrideReason:  item.OverrideReason,
+		CreatedAt:       createdAt,
+		UpdatedAt:       updatedAt,
+	}
+}

--- a/02-task-2-craftsbite/craftsbite_backend/internal/repository/repository.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/repository/repository.go
@@ -1,2 +1,5 @@
-// Package repository provides DynamoDB data-access functions
 package repository
+
+import "time"
+
+const rfc3339 = time.RFC3339

--- a/02-task-2-craftsbite/craftsbite_backend/internal/repository/types.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/repository/types.go
@@ -1,0 +1,57 @@
+package repository
+
+import "time"
+
+type MealParticipation struct {
+	UserID          string
+	Date            string
+	MealType        string
+	IsParticipating bool
+	OverrideBy      string
+	OverrideReason  string
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+}
+
+type DaySchedule struct {
+	Date           string
+	DayStatus      string
+	AvailableMeals []string
+	Reason         string
+	CreatedBy      string
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}
+
+type mealItem struct {
+	PK              string `dynamodbav:"PK"`
+	SK              string `dynamodbav:"SK"`
+	GSI1PK          string `dynamodbav:"GSI1PK"`
+	GSI1SK          string `dynamodbav:"GSI1SK"`
+	UserID          string `dynamodbav:"user_id"`
+	Date            string `dynamodbav:"date"`
+	MealType        string `dynamodbav:"meal_type"`
+	IsParticipating bool   `dynamodbav:"is_participating"`
+	OverrideBy      string `dynamodbav:"override_by"`
+	OverrideReason  string `dynamodbav:"override_reason"`
+	CreatedAt       string `dynamodbav:"created_at"`
+	UpdatedAt       string `dynamodbav:"updated_at"`
+}
+
+type dayScheduleItem struct {
+	PK             string   `dynamodbav:"PK"`
+	SK             string   `dynamodbav:"SK"`
+	Date           string   `dynamodbav:"date"`
+	DayStatus      string   `dynamodbav:"day_status"`
+	AvailableMeals []string `dynamodbav:"available_meals"`
+	Reason         string   `dynamodbav:"reason"`
+	CreatedBy      string   `dynamodbav:"created_by"`
+	CreatedAt      string   `dynamodbav:"created_at"`
+	UpdatedAt      string   `dynamodbav:"updated_at"`
+}
+
+type dayMealsItem struct {
+	PK    string   `dynamodbav:"PK"`
+	SK    string   `dynamodbav:"SK"`
+	Meals []string `dynamodbav:"meals"`
+}

--- a/02-task-2-craftsbite/craftsbite_backend/internal/services/cutoff.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/services/cutoff.go
@@ -1,0 +1,68 @@
+package services
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+const (
+	defaultCutoffTime = "21:00"
+	defaultTimezone   = "Asia/Dhaka"
+
+	maxDaysAhead = 7
+)
+
+func IsBeforeCutoff(targetDate string) (bool, error) {
+	return isBeforeCutoffAt(targetDate, time.Now())
+}
+
+func isBeforeCutoffAt(targetDate string, now time.Time) (bool, error) {
+	loc, err := loadLocation()
+	if err != nil {
+		return false, err
+	}
+
+	cutoffStr := os.Getenv("CUTOFF_TIME")
+	if cutoffStr == "" {
+		cutoffStr = defaultCutoffTime
+	}
+
+	var cutoffHour, cutoffMin int
+	if _, err := fmt.Sscanf(cutoffStr, "%d:%d", &cutoffHour, &cutoffMin); err != nil {
+		return false, fmt.Errorf("cutoff: invalid CUTOFF_TIME %q: %w", cutoffStr, err)
+	}
+
+	target, err := time.ParseInLocation("2006-01-02", targetDate, loc)
+	if err != nil {
+		return false, fmt.Errorf("cutoff: invalid targetDate %q: %w", targetDate, err)
+	}
+
+	nowLocal := now.In(loc)
+	todayLocal := time.Date(nowLocal.Year(), nowLocal.Month(), nowLocal.Day(), 0, 0, 0, 0, loc)
+
+	if !todayLocal.Before(target) {
+		return false, nil
+	}
+
+	daysAhead := int(target.Sub(todayLocal).Hours() / 24)
+	if daysAhead > maxDaysAhead {
+		return false, nil
+	}
+
+	dayBeforeTarget := target.AddDate(0, 0, -1)
+	cutoff := time.Date(dayBeforeTarget.Year(), dayBeforeTarget.Month(), dayBeforeTarget.Day(), cutoffHour, cutoffMin, 0, 0, loc)
+	return nowLocal.Before(cutoff), nil
+}
+
+func loadLocation() (*time.Location, error) {
+	tz := os.Getenv("TIMEZONE")
+	if tz == "" {
+		tz = defaultTimezone
+	}
+	loc, err := time.LoadLocation(tz)
+	if err != nil {
+		return nil, fmt.Errorf("cutoff: invalid TIMEZONE %q: %w", tz, err)
+	}
+	return loc, nil
+}

--- a/02-task-2-craftsbite/craftsbite_backend/internal/services/cutoff_test.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/services/cutoff_test.go
@@ -1,0 +1,144 @@
+package services
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func dhakaLoc(t *testing.T) *time.Location {
+	t.Helper()
+	loc, err := time.LoadLocation("Asia/Dhaka")
+	if err != nil {
+		t.Skipf("timezone Asia/Dhaka not available: %v", err)
+	}
+	return loc
+}
+
+func TestScenario_RequestMar10_TargetMar11(t *testing.T) {
+	t.Setenv("CUTOFF_TIME", "21:00")
+	t.Setenv("TIMEZONE", "Asia/Dhaka")
+
+	loc := dhakaLoc(t)
+
+	const target = "2026-03-11"
+
+	t.Run("before cutoff (18:00) — should be allowed", func(t *testing.T) {
+		now := time.Date(2026, 3, 10, 18, 0, 0, 0, loc)
+		got, err := isBeforeCutoffAt(target, now)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !got {
+			t.Errorf("expected true (update allowed): request=2026-03-10 18:00, target=%s", target)
+		}
+	})
+
+	t.Run("after cutoff (22:00) — should be denied", func(t *testing.T) {
+		now := time.Date(2026, 3, 10, 22, 0, 0, 0, loc)
+		got, err := isBeforeCutoffAt(target, now)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got {
+			t.Errorf("expected false (update denied): request=2026-03-10 22:00, target=%s", target)
+		}
+	})
+}
+
+func TestScenario_RequestMar10_2300_TargetMar10(t *testing.T) {
+	t.Setenv("CUTOFF_TIME", "21:00")
+	t.Setenv("TIMEZONE", "Asia/Dhaka")
+
+	loc := dhakaLoc(t)
+
+	now := time.Date(2026, 3, 10, 23, 0, 0, 0, loc)
+	const target = "2026-03-10"
+
+	got, err := isBeforeCutoffAt(target, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got {
+		t.Errorf("expected false: same-day update at 23:00 must be denied for target=%s", target)
+	}
+}
+
+func TestMultiDayLookahead(t *testing.T) {
+	t.Setenv("CUTOFF_TIME", "21:00")
+	t.Setenv("TIMEZONE", "Asia/Dhaka")
+
+	loc := dhakaLoc(t)
+
+	now := time.Date(2026, 3, 10, 10, 0, 0, 0, loc)
+
+	tests := []struct {
+		name   string
+		target string
+		wantOk bool
+	}{
+		{"1 day ahead (Mar 11) — allowed", "2026-03-11", true},
+		{"2 days ahead (Mar 12) — allowed", "2026-03-12", true},
+		{"3 days ahead (Mar 13) — allowed", "2026-03-13", true},
+		{"7 days ahead (Mar 17) — allowed (boundary)", "2026-03-17", true},
+		{"8 days ahead (Mar 18) — denied by cap", "2026-03-18", false},
+		{"14 days ahead (Mar 24) — denied by cap", "2026-03-24", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := isBeforeCutoffAt(tc.target, now)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.wantOk {
+				t.Errorf("isBeforeCutoffAt(%q, 2026-03-10 10:00) = %v; want %v",
+					tc.target, got, tc.wantOk)
+			}
+		})
+	}
+}
+
+func TestPostCutoff_StillAllowsFurtherDays(t *testing.T) {
+	t.Setenv("CUTOFF_TIME", "21:00")
+	t.Setenv("TIMEZONE", "Asia/Dhaka")
+
+	loc := dhakaLoc(t)
+
+	now := time.Date(2026, 3, 10, 23, 45, 0, 0, loc)
+
+	tests := []struct {
+		name   string
+		target string
+		wantOk bool
+	}{
+		{"Mar 11 — denied (cutoff was Mar 10 21:00)", "2026-03-11", false},
+		{"Mar 12 — allowed (cutoff is Mar 11 21:00)", "2026-03-12", true},
+		{"Mar 13 — allowed (cutoff is Mar 12 21:00)", "2026-03-13", true},
+		{"Mar 17 — allowed (7-day boundary)", "2026-03-17", true},
+		{"Mar 18 — denied (8 days ahead)", "2026-03-18", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := isBeforeCutoffAt(tc.target, now)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.wantOk {
+				t.Errorf("isBeforeCutoffAt(%q, 2026-03-10 23:45) = %v; want %v",
+					tc.target, got, tc.wantOk)
+			}
+		})
+	}
+}
+
+func TestIsBeforeCutoff_InvalidTimezone(t *testing.T) {
+	os.Setenv("TIMEZONE", "NotAReal/Timezone")
+	t.Cleanup(func() { os.Unsetenv("TIMEZONE") })
+
+	_, err := isBeforeCutoffAt("2026-03-10", time.Now())
+	if err == nil {
+		t.Fatal("expected error for invalid timezone; got nil")
+	}
+}

--- a/02-task-2-craftsbite/craftsbite_backend/internal/services/participation.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/services/participation.go
@@ -1,0 +1,170 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/sayad-ika/craftsbite/internal/repository"
+)
+
+type ResolvedStatus struct {
+	MealType string
+	Status   string
+	Source   string
+}
+
+var (
+	ErrPastDate        = errors.New("cannot update participation for today or past date")
+	ErrCutoffPassed    = errors.New("cutoff has passed for this date")
+	ErrTooFarAhead     = errors.New("cannot update participation more than 7 days in advance")
+	ErrDayClosed       = errors.New("office is closed on this date")
+	ErrMealUnavailable = errors.New("meal is not available on this date")
+	ErrNoMeals         = errors.New("no meals are configured for this date")
+)
+
+func Resolve(schedule *repository.DaySchedule, availableMeals []string, record *repository.MealParticipation, mealType string) ResolvedStatus {
+	if schedule != nil && (schedule.DayStatus == "office_closed" || schedule.DayStatus == "govt_holiday") {
+		return ResolvedStatus{MealType: mealType, Status: "unavailable", Source: "day_schedule_unavailable"}
+	}
+	if !containsMeal(availableMeals, mealType) {
+		return ResolvedStatus{MealType: mealType, Status: "unavailable", Source: "day_schedule_unavailable"}
+	}
+
+	if record != nil {
+		status := "opted_out"
+		if record.IsParticipating {
+			status = "opted_in"
+		}
+		return ResolvedStatus{MealType: mealType, Status: status, Source: "explicit"}
+	}
+
+	return ResolvedStatus{MealType: mealType, Status: "opted_in", Source: "system_default"}
+}
+
+func GetUserMealStatus(ctx context.Context, client *dynamodb.Client, table, userID, date string) ([]ResolvedStatus, error) {
+	schedule, err := repository.GetDay(ctx, client, table, date)
+	if err != nil {
+		return nil, fmt.Errorf("participation: GetUserMealStatus schedule: %w", err)
+	}
+
+	availableMeals, err := repository.GetAvailableMeals(ctx, client, table, date)
+	if err != nil {
+		return nil, fmt.Errorf("participation: GetUserMealStatus available meals: %w", err)
+	}
+	if len(availableMeals) == 0 {
+		return []ResolvedStatus{}, nil
+	}
+
+	records, err := repository.GetParticipationsByUserDate(ctx, client, table, userID, date)
+	if err != nil {
+		return nil, fmt.Errorf("participation: GetUserMealStatus records: %w", err)
+	}
+
+	// Build a lookup from mealType → record.
+	recordByMeal := make(map[string]*repository.MealParticipation, len(records))
+	for i := range records {
+		recordByMeal[records[i].MealType] = &records[i]
+	}
+
+	statuses := make([]ResolvedStatus, 0, len(availableMeals))
+	for _, meal := range availableMeals {
+		statuses = append(statuses, Resolve(schedule, availableMeals, recordByMeal[meal], meal))
+	}
+	return statuses, nil
+}
+
+func UpdateParticipation(ctx context.Context, client *dynamodb.Client, table, userID, date, mealType string, isParticipating bool) ([]ResolvedStatus, error) {
+	loc, err := loadLocation()
+	if err != nil {
+		return nil, fmt.Errorf("participation: load timezone: %w", err)
+	}
+	nowLocal := time.Now().In(loc)
+	today := nowLocal.Format("2006-01-02")
+
+	if date <= today {
+		return nil, ErrPastDate
+	}
+	if date > today {
+		// Reject dates beyond the hard lookahead cap before hitting the cutoff check.
+		target, parseErr := time.ParseInLocation("2006-01-02", date, loc)
+		if parseErr != nil {
+			return nil, fmt.Errorf("participation: invalid date %q: %w", date, parseErr)
+		}
+		todayMidnight := time.Date(nowLocal.Year(), nowLocal.Month(), nowLocal.Day(), 0, 0, 0, 0, loc)
+		if int(target.Sub(todayMidnight).Hours()/24) > maxDaysAhead {
+			return nil, ErrTooFarAhead
+		}
+
+		ok, err := IsBeforeCutoff(date)
+		if err != nil {
+			return nil, fmt.Errorf("participation: cutoff check: %w", err)
+		}
+		if !ok {
+			return nil, ErrCutoffPassed
+		}
+	}
+
+	schedule, err := repository.GetDay(ctx, client, table, date)
+	if err != nil {
+		return nil, fmt.Errorf("participation: UpdateParticipation schedule: %w", err)
+	}
+
+	if schedule != nil && (schedule.DayStatus == "office_closed" || schedule.DayStatus == "govt_holiday") {
+		return nil, ErrDayClosed
+	}
+
+	availableMeals, err := repository.GetAvailableMeals(ctx, client, table, date)
+	if err != nil {
+		return nil, fmt.Errorf("participation: UpdateParticipation available meals: %w", err)
+	}
+	if len(availableMeals) == 0 {
+		return nil, ErrNoMeals
+	}
+
+	if mealType == "" {
+		mealType = "all"
+	}
+
+	var mealsToWrite []string
+
+	if mealType == "all" {
+		mealsToWrite = availableMeals
+	} else {
+		if !containsMeal(availableMeals, mealType) {
+			return nil, ErrMealUnavailable
+		}
+		mealsToWrite = []string{mealType}
+	}
+
+	now := time.Now().UTC()
+	for _, meal := range mealsToWrite {
+		p := repository.MealParticipation{
+			UserID:          userID,
+			Date:            date,
+			MealType:        meal,
+			IsParticipating: isParticipating,
+			CreatedAt:       now,
+			UpdatedAt:       now,
+		}
+		if err := repository.UpsertParticipation(ctx, client, table, p); err != nil {
+			return nil, fmt.Errorf("participation: upsert %s: %w", meal, err)
+		}
+	}
+
+	return GetUserMealStatus(ctx, client, table, userID, date)
+}
+
+func containsMeal(available []string, meal string) bool {
+	norm := strings.Map(unicode.ToLower, meal)
+	for _, m := range available {
+		if strings.Map(unicode.ToLower, m) == norm {
+			return true
+		}
+	}
+	return false
+}

--- a/02-task-2-craftsbite/craftsbite_backend/internal/services/participation_test.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/services/participation_test.go
@@ -1,0 +1,102 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/sayad-ika/craftsbite/internal/repository"
+)
+
+func TestResolve(t *testing.T) {
+	normalSchedule := &repository.DaySchedule{
+		DayStatus:      "normal",
+		AvailableMeals: []string{"lunch", "snacks"},
+	}
+	closedSchedule := &repository.DaySchedule{
+		DayStatus:      "office_closed",
+		AvailableMeals: []string{},
+	}
+	partialMeals := []string{"lunch"}
+
+	optedOutRecord := &repository.MealParticipation{IsParticipating: false}
+	optedInRecord := &repository.MealParticipation{IsParticipating: true}
+
+	tests := []struct {
+		name           string
+		schedule       *repository.DaySchedule
+		availableMeals []string
+		record         *repository.MealParticipation
+		mealType       string
+		wantStatus     string
+		wantSource     string
+	}{
+		{
+			name:           "meal unavailable - schedule closed",
+			schedule:       closedSchedule,
+			availableMeals: []string{},
+			record:         nil,
+			mealType:       "lunch",
+			wantStatus:     "unavailable",
+			wantSource:     "day_schedule_unavailable",
+		},
+		{
+			name:           "meal unavailable - not in available list",
+			schedule:       normalSchedule,
+			availableMeals: partialMeals, // only lunch
+			record:         nil,
+			mealType:       "snacks",
+			wantStatus:     "unavailable",
+			wantSource:     "day_schedule_unavailable",
+		},
+		{
+			name:           "explicit opt-out",
+			schedule:       normalSchedule,
+			availableMeals: []string{"lunch", "snacks"},
+			record:         optedOutRecord,
+			mealType:       "lunch",
+			wantStatus:     "opted_out",
+			wantSource:     "explicit",
+		},
+		{
+			name:           "explicit opt-in",
+			schedule:       normalSchedule,
+			availableMeals: []string{"lunch", "snacks"},
+			record:         optedInRecord,
+			mealType:       "lunch",
+			wantStatus:     "opted_in",
+			wantSource:     "explicit",
+		},
+		{
+			name:           "no record, meal available - system default",
+			schedule:       normalSchedule,
+			availableMeals: []string{"lunch", "snacks"},
+			record:         nil,
+			mealType:       "lunch",
+			wantStatus:     "opted_in",
+			wantSource:     "system_default",
+		},
+		{
+			name:           "nil schedule - all meals available, system default",
+			schedule:       nil,
+			availableMeals: []string{"lunch", "snacks"},
+			record:         nil,
+			mealType:       "lunch",
+			wantStatus:     "opted_in",
+			wantSource:     "system_default",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Resolve(tc.schedule, tc.availableMeals, tc.record, tc.mealType)
+			if got.Status != tc.wantStatus {
+				t.Errorf("Status = %q; want %q", got.Status, tc.wantStatus)
+			}
+			if got.Source != tc.wantSource {
+				t.Errorf("Source = %q; want %q", got.Source, tc.wantSource)
+			}
+			if got.MealType != tc.mealType {
+				t.Errorf("MealType = %q; want %q", got.MealType, tc.mealType)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #43

### Dependencies
- #69

### What does this PR do?

Implements the `/meal` slash command end-to-end: DynamoDB repository layer for meal participation and day schedules, cutoff enforcement service, participation resolution service, and the `self` Lambda handler wired together in `cmd/self/main.go`.

### Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation

### What was changed

- **`internal/repository/types.go`** — Domain structs (`MealParticipation`, `DaySchedule`) and DynamoDB wire types.
- **`internal/repository/day.go`** — `GetDay` and `GetAvailableMeals`. Returns `nil` (not a default) when no `MEALS` item exists; callers receive `ErrNoMeals`.
- **`internal/repository/meal_participation.go`** — `GetParticipation`, `GetParticipationsByUserDate`, `UpsertParticipation`, and `mealItemToParticipation`.
- **`internal/repository/repository.go`** — Package declaration; exposes the shared `rfc3339` constant.
- **`internal/services/cutoff.go`** — `IsBeforeCutoff(date)`: cutoff = `(date − 1 day) at CUTOFF_TIME in TIMEZONE`. Core logic extracted into `isBeforeCutoffAt` for unit-testability.
- **`internal/services/participation.go`** — Five sentinel errors, `ResolvedStatus` type, and `Resolve()` / `GetUserMealStatus()` / `UpdateParticipation()`. Guard order: past-date → cutoff → office-closed → no meals → meal unavailable → write. Fan-out on `"all"` or empty `mealType` reads from DynamoDB, never hardcoded.
- **`cmd/self/main.go`** — Rewritten from stub. Fully implements `/meal`; `/location` and `/status` return "coming soon."

### Changelog

Feature: Users can now opt in or out of individual meals — or all meals for a date at once — using `/meal` in Discord.

### How to Test

1. **Unit tests** (no cloud required): `go test ./internal/services/... -v`
2. **Join the test server** and run commands in `#1-meal-cmd-test`: https://discord.gg/f5yhCxvP

### How QA Should Test

> All commands go in **1-meal-cmd-test** — replies are ephemeral.

| Command | Expected Reply |
|---|---|
| `/meal date:<YYYY-MM-DD> meal:lunch status:in` | `Lunch ✓` |
| `/meal date:<YYYY-MM-DD> meal:all status:out` | Opt-out for every available meal |
| `/meal date:<YYYY-MM-DD> status:in` *(meal omitted)* | Same fan-out as `all` |
| `/meal date:<YYYY-MM-DD> meal:lunch status:in` | "Updates for \<date\> are closed. Cutoff was \<date−1\> at 9:00 PM." |
| `/meal date:2020-01-01 meal:lunch status:in` | "Cannot update participation for a past date." |
| `/meal` on an `office_closed` date | "Office is closed on \<date\> — no meals are available." |
| `/meal` on a date with no `MEALS` item | "No meals are configured for \<date\>." |
| `/meal date:<YYYY-MM-DD> meal:snacks` when only `lunch` available | "That meal is not available on \<date\>." |

If commands produce no reply, check CloudWatch: `aws logs tail /aws/lambda/<self-lambda-name> --follow`

### Rollback Plan

Redeploy the previous Lambda zip. No DynamoDB schema changes — all new items use the existing `craftsbite` table structure.

### Checklist

- [x] Code follows project style guidelines
- [x] Linting and type checks pass
- [x] All tests pass (`go test ./internal/... ✓`, `go build ./cmd/self/ ✓`)
- [x] Tests added for new changes
- [x] Documentation updated (`technical_doc.md` §16–§19)

### Note for Reviewer

- `Resolve()` is a pure function — all six test cases run without a DynamoDB mock.
- `IsBeforeCutoff` treats same-day targets as expired. Confirm this matches product expectations.
- Valid `meal` values: `lunch`, `snacks`, `event_dinner`, `optional_dinner`, `all`.
- Dates need an explicit `DAY#<date> MEALS` record before `/meal` will work — run `seed_schedule.go` to populate the next 5 days.