### PR TITLE
[PR-10] doc: update technical_doc added command usage section for meal-cmd

### DIFF
--- a/02-task-2-craftsbite/docs/technical_doc.md
+++ b/02-task-2-craftsbite/docs/technical_doc.md
@@ -288,3 +288,24 @@ Enriched payload: `userID`, `role`, `discordId`, `commandName`, `options`, `inte
 | `/admin`        | `action` (req: `create-user\|update-role\|deactivate-user\|create-team\|add-member\|remove-member`), plus action-specific options                        | Admin only.                                                                                                                                         |
 
 ---
+
+## 16. Command Usage
+
+### `/meal`
+
+```
+/meal date:<YYYY-MM-DD> status:<in|out> [meal:<lunch|snacks|event_dinner|optional_dinner|all>]
+```
+
+Opts in or out of meals for a given date. If `meal` is omitted or set to `all`, the status is applied to every available meal for that date.
+
+| Scenario            | Reply                                                                        |
+| ------------------- | ---------------------------------------------------------------------------- |
+| Success             | Updated status for all meals on that date (`✓` in, `✗` out, `—` unavailable) |
+| Past date           | "Cannot update participation for a past date."                               |
+| Cutoff passed       | "Updates for \<date\> are closed. Cutoff was \<date−1\> at 9:00 PM."         |
+| Office closed       | "Office is closed on \<date\> — no meals are available."                     |
+| No meals configured | "No meals are configured for \<date\>."                                      |
+| Meal not available  | "That meal is not available on \<date\>."                                    |
+
+---


### PR DESCRIPTION
Closes #43 

## Dependencies

- #70 

## What does this PR do?

Adds §16 `/meal` to `technical_doc.md` — command syntax, options, and all validation error messages.

## Type of Change

- [x] Documentation

## What was changed

- **Section 16 — `/meal`:** Added command syntax, fan-out behavior note, and error reply table.

## Changelog

None: not user visible

## How to Test

Read §16 and verify it matches the implementation in `cmd/self/main.go` and `internal/services/participation.go`.

## How QA Should Test

Not applicable — documentation only.

## Rollback Plan

No rollback needed — documentation change only.

## Checklist

- [ ] My code follows the project style guidelines
- [ ] Code passes linting and type checks
- [ ] All tests pass
- [ ] I have added tests for my changes (if applicable)
- [x] I have updated documentation (if applicable)