### PR TITLE
[PR-11] doc: update tech_doc, added location-cmd for command usage

### DIFF
--- a/02-task-2-craftsbite/docs/technical_doc.md
+++ b/02-task-2-craftsbite/docs/technical_doc.md
@@ -308,4 +308,19 @@ Opts in or out of meals for a given date. If `meal` is omitted or set to `all`, 
 | No meals configured | "No meals are configured for \<date\>."                                      |
 | Meal not available  | "That meal is not available on \<date\>."                                    |
 
+### `/location`
+
+```
+/location date:<YYYY-MM-DD> location:<office|wfh>
+```
+
+Sets work location for a given date. On success, replies with the updated location and all meal statuses for that date.
+
+| Scenario         | Reply                                                              |
+| ---------------- | ------------------------------------------------------------------ |
+| Success (office) | `🏢 Office` + meal statuses                                        |
+| Success (WFH)    | `🏠 WFH` + meal statuses                                           |
+| Past date        | "Cannot set work location for a past date."                        |
+| Cutoff passed    | "Updates for \<date\> are closed. Cutoff was \<date−1\> at 9:00 PM |
+
 ---


### PR DESCRIPTION
Closes #44 

## Dependencies

- #70  must be merged — `technical_doc.md` is updated there.
- `/meal` doc PR must be merged — §16 is added there; `/location` appends §17.

## What does this PR do?

Adds §17 `/location` to `technical_doc.md` — command syntax, options, and all validation error messages.

## Type of Change

- [x] Documentation

## What was changed

- **Section 17 — `/location`:** Added command syntax, success reply format, and error reply table.

## Changelog

None: not user visible

## How to Test

Read §17 and verify it matches the implementation in `cmd/self/main.go` and `internal/services/location.go`.

## How QA Should Test

Not applicable — documentation only.

## Rollback Plan

No rollback needed — documentation change only.

## Checklist

- [ ] My code follows the project style guidelines
- [ ] Code passes linting and type checks
- [ ] All tests pass
- [ ] I have added tests for my changes (if applicable)
- [x] I have updated documentation (if applicable)