### PR TITLE
[PR-14] feat: implement /team-summary command — repository layer, and management Lambda

### DIFF
--- a/02-task-2-craftsbite/craftsbite_backend/cmd/management/main.go
+++ b/02-task-2-craftsbite/craftsbite_backend/cmd/management/main.go
@@ -1,12 +1,139 @@
 package main
 
-import "github.com/aws/aws-lambda-go/lambda"
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	appconfig "github.com/sayad-ika/craftsbite/internal/config"
+	"github.com/sayad-ika/craftsbite/internal/discord"
+	"github.com/sayad-ika/craftsbite/internal/dynamo"
+	"github.com/sayad-ika/craftsbite/internal/repository"
+	"github.com/sayad-ika/craftsbite/internal/services"
+)
+
+type CommandEvent struct {
+	UserID           string                 `json:"userID"`
+	Role             string                 `json:"role"`
+	DiscordID        string                 `json:"discordId"`
+	CommandName      string                 `json:"commandName"`
+	Options          map[string]interface{} `json:"options"`
+	InteractionToken string                 `json:"interactionToken"`
+	ApplicationID    string                 `json:"applicationId"`
+}
+
+var (
+	cfgOnce sync.Once
+	cfg     *appconfig.Config
+)
+
+func getConfig() *appconfig.Config {
+	cfgOnce.Do(func() {
+		cfg = appconfig.MustLoad()
+	})
+	return cfg
+}
+
+func handler(ctx context.Context, event CommandEvent) error {
+	c := getConfig()
+	client := dynamo.GetClient(c)
+
+	var replyContent string
+
+	switch event.CommandName {
+	case "team-summary":
+		replyContent = handleTeamSummary(ctx, client, c.DynamoDBTable, event)
+	case "override":
+		replyContent = "This feature is coming soon."
+	default:
+		replyContent = fmt.Sprintf("Unknown command: /%s", event.CommandName)
+	}
+
+	return discord.SendFollowup(event.ApplicationID, event.InteractionToken, replyContent)
+}
+
+func handleTeamSummary(ctx context.Context, client *dynamodb.Client, table string, event CommandEvent) string {
+	if event.Role != "team_lead" && event.Role != "admin" {
+		return "You do not have permission to use `/team-summary`."
+	}
+
+	date, ok := optString(event.Options, "date")
+	if !ok || date == "" {
+		return "Please provide a date. Example: `/team-summary date:2026-03-10`"
+	}
+
+	teams, err := repository.FindTeamsByLeadID(ctx, client, table, event.UserID)
+	if err != nil {
+		return "Something went wrong fetching your team. Please try again later."
+	}
+	if len(teams) == 0 {
+		return "You are not assigned as a team lead to any team."
+	}
+
+	team, err := repository.GetTeamByID(ctx, client, table, teams[0].ID)
+	if err != nil || team == nil {
+		return "Team not found. Please try again later."
+	}
+
+	summary, err := services.GetTeamSummary(ctx, client, table, teams[0].ID, date)
+	if err != nil {
+		return "Something went wrong fetching the team summary. Please try again later."
+	}
+
+	return formatTeamSummary(team, date, summary)
+}
+
+func optString(opts map[string]interface{}, key string) (string, bool) {
+	v, ok := opts[key]
+	if !ok {
+		return "", false
+	}
+	s, ok := v.(string)
+	return s, ok
+}
+
+func formatTeamSummary(team *repository.Team, date string, summary *services.TeamSummary) string {
+	if summary.MemberCount == 0 {
+		return fmt.Sprintf("Team %s — %s has no members.", team.Name, date)
+	}
+
+	mealTypes := make([]string, 0, len(summary.MealCounts))
+	for mt := range summary.MealCounts {
+		mealTypes = append(mealTypes, mt)
+	}
+	sort.Strings(mealTypes)
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Team %s — %s (%d members)\n", team.Name, date, summary.MemberCount)
+
+	if len(mealTypes) > 0 {
+		parts := make([]string, 0, len(mealTypes))
+		for _, mt := range mealTypes {
+			parts = append(parts, fmt.Sprintf("%s %d/%d", displayMealName(mt), summary.MealCounts[mt], summary.MemberCount))
+		}
+		fmt.Fprintf(&sb, "Meals:    %s\n", strings.Join(parts, "  │  "))
+	}
+
+	officeCount := summary.MemberCount - summary.WFHCount
+	fmt.Fprintf(&sb, "Location: Office %d/%d  │  WFH %d/%d", officeCount, summary.MemberCount, summary.WFHCount, summary.MemberCount)
+
+	return sb.String()
+}
+
+func displayMealName(s string) string {
+	words := strings.Split(strings.ReplaceAll(s, "_", " "), " ")
+	for i, w := range words {
+		if len(w) > 0 {
+			words[i] = strings.ToUpper(w[:1]) + w[1:]
+		}
+	}
+	return strings.Join(words, " ")
+}
 
 func main() {
 	lambda.Start(handler)
-}
-
-func handler() error {
-	// TODO: Management slash command
-	return nil
 }

--- a/02-task-2-craftsbite/craftsbite_backend/internal/discord/dispatch.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/discord/dispatch.go
@@ -8,7 +8,7 @@ var commandACL = map[string]map[string]struct{}{
 	"location":     {"employee": {}, "team_lead": {}, "admin": {}, "logistics": {}},
 	"status":       {"employee": {}, "team_lead": {}, "admin": {}, "logistics": {}},
 	"override":     {"team_lead": {}, "admin": {}},
-	"team-summary": {"team_lead": {}, "admin": {}, "logistics": {}},
+	"team-summary": {"team_lead": {}, "admin": {}},
 	"headcount":    {"admin": {}, "logistics": {}},
 	"set-day":      {"admin": {}},
 	"admin":        {"admin": {}},

--- a/02-task-2-craftsbite/craftsbite_backend/internal/repository/teams.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/repository/teams.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
@@ -10,9 +11,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
 
-func GetTeamByID(ctx context.Context, client *dynamodb.Client, table, teamID string) (*Team, error) {
+func GetTeamByID(ctx context.Context, client *dynamodb.Client, tableName, teamID string) (*Team, error) {
 	out, err := client.GetItem(ctx, &dynamodb.GetItemInput{
-		TableName: aws.String(table),
+		TableName: aws.String(tableName),
 		Key: map[string]types.AttributeValue{
 			"PK": &types.AttributeValueMemberS{Value: "TEAM#" + teamID},
 			"SK": &types.AttributeValueMemberS{Value: "METADATA"},
@@ -29,11 +30,68 @@ func GetTeamByID(ctx context.Context, client *dynamodb.Client, table, teamID str
 	if err := attributevalue.UnmarshalMap(out.Item, &item); err != nil {
 		return nil, fmt.Errorf("repository: GetTeamByID unmarshal: %w", err)
 	}
-
 	return &Team{
-		ID:          item.ID,
-		Name:        item.Name,
-		Description: item.Description,
-		LeadID:      item.TeamLeadID,
+		ID:         item.ID,
+		Name:       item.Name,
+		TeamLeadID: item.TeamLeadID,
+		Active:     item.Active,
 	}, nil
+}
+
+func GetTeamMembers(ctx context.Context, client *dynamodb.Client, tableName, teamID string) ([]TeamMember, error) {
+	out, err := client.Query(ctx, &dynamodb.QueryInput{
+		TableName:              aws.String(tableName),
+		KeyConditionExpression: aws.String("PK = :pk AND begins_with(SK, :prefix)"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":pk":     &types.AttributeValueMemberS{Value: "TEAM#" + teamID},
+			":prefix": &types.AttributeValueMemberS{Value: "MEMBER#"},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("repository: GetTeamMembers: %w", err)
+	}
+
+	results := make([]TeamMember, 0, len(out.Items))
+	for _, rawItem := range out.Items {
+		var item teamMemberItem
+		if err := attributevalue.UnmarshalMap(rawItem, &item); err != nil {
+			return nil, fmt.Errorf("repository: GetTeamMembers unmarshal: %w", err)
+		}
+		joinedAt, _ := time.Parse(rfc3339, item.JoinedAt)
+		results = append(results, TeamMember{
+			TeamID:   item.TeamID,
+			UserID:   item.UserID,
+			JoinedAt: joinedAt,
+		})
+	}
+	return results, nil
+}
+
+func FindTeamsByLeadID(ctx context.Context, client *dynamodb.Client, tableName, leadUserID string) ([]Team, error) {
+	out, err := client.Query(ctx, &dynamodb.QueryInput{
+		TableName:              aws.String(tableName),
+		IndexName:              aws.String("GSI1"),
+		KeyConditionExpression: aws.String("GSI1PK = :pk"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":pk": &types.AttributeValueMemberS{Value: "TEAMLEAD#" + leadUserID},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("repository: FindTeamsByLeadID: %w", err)
+	}
+
+	results := make([]Team, 0, len(out.Items))
+	for _, rawItem := range out.Items {
+		var item teamMetadataItem
+		if err := attributevalue.UnmarshalMap(rawItem, &item); err != nil {
+			return nil, fmt.Errorf("repository: FindTeamsByLeadID unmarshal: %w", err)
+		}
+		results = append(results, Team{
+			ID:         item.ID,
+			Name:       item.Name,
+			TeamLeadID: item.TeamLeadID,
+			Active:     item.Active,
+		})
+	}
+	return results, nil
 }

--- a/02-task-2-craftsbite/craftsbite_backend/internal/repository/types.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/repository/types.go
@@ -67,16 +67,16 @@ type WorkLocation struct {
 }
 
 type workLocationItem struct {
-	PK        string `dynamodbav:"PK"`
-	SK        string `dynamodbav:"SK"`
-	GSI1PK    string `dynamodbav:"GSI1PK"`
-	GSI1SK    string `dynamodbav:"GSI1SK"`
-	UserID    string `dynamodbav:"user_id"`
-	Date      string `dynamodbav:"date"`
-	Location  string `dynamodbav:"location"`
-	SetBy     string `dynamodbav:"set_by"`
-	Reason    string `dynamodbav:"reason"`
-	WFHMonth  string `dynamodbav:"wfh_month,omitempty"`
+	PK       string `dynamodbav:"PK"`
+	SK       string `dynamodbav:"SK"`
+	GSI1PK  string `dynamodbav:"GSI1PK"`
+	GSI1SK  string `dynamodbav:"GSI1SK"`
+	UserID   string `dynamodbav:"user_id"`
+	Date     string `dynamodbav:"date"`
+	Location string `dynamodbav:"location"`
+	SetBy    string `dynamodbav:"set_by"`
+	Reason   string `dynamodbav:"reason"`
+	WFHMonth string `dynamodbav:"wfh_month,omitempty"`
 	CreatedAt string `dynamodbav:"created_at"`
 	UpdatedAt string `dynamodbav:"updated_at"`
 }
@@ -100,16 +100,30 @@ type userProfileItem struct {
 }
 
 type Team struct {
-	ID          string
-	Name        string
-	Description string
-	LeadID      string
+	ID         string
+	Name       string
+	TeamLeadID string
+	Active     bool
+}
+
+type TeamMember struct {
+	TeamID   string
+	UserID   string
+	JoinedAt time.Time
 }
 
 type teamMetadataItem struct {
-	ID          string `dynamodbav:"id"`
-	Name        string `dynamodbav:"name"`
-	Description string `dynamodbav:"description"`
-	TeamLeadID  string `dynamodbav:"team_lead_id"`
+	ID         string `dynamodbav:"id"`
+	Name       string `dynamodbav:"name"`
+	TeamLeadID string `dynamodbav:"team_lead_id"`
+	Active     bool   `dynamodbav:"active"`
+	CreatedAt  string `dynamodbav:"created_at"`
+	UpdatedAt  string `dynamodbav:"updated_at"`
+}
+
+type teamMemberItem struct {
+	TeamID   string `dynamodbav:"team_id"`
+	UserID   string `dynamodbav:"user_id"`
+	JoinedAt string `dynamodbav:"joined_at"`
 }
 

--- a/02-task-2-craftsbite/craftsbite_backend/internal/repository/users.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/repository/users.go
@@ -69,3 +69,31 @@ func ListActiveUsers(ctx context.Context, client *dynamodb.Client, tableName str
 	}
 	return results, nil
 }
+
+func GetUserByID(ctx context.Context, client *dynamodb.Client, tableName, userID string) (*User, error) {
+	out, err := client.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName: aws.String(tableName),
+		Key: map[string]types.AttributeValue{
+			"PK": &types.AttributeValueMemberS{Value: "USER#" + userID},
+			"SK": &types.AttributeValueMemberS{Value: "PROFILE"},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("repository: GetUserByID: %w", err)
+	}
+	if out.Item == nil {
+		return nil, nil
+	}
+
+	var item userProfileItem
+	if err := attributevalue.UnmarshalMap(out.Item, &item); err != nil {
+		return nil, fmt.Errorf("repository: GetUserByID unmarshal: %w", err)
+	}
+	return &User{
+		ID:     item.ID,
+		Email:  item.Email,
+		Name:   item.Name,
+		Role:   item.Role,
+		Active: item.Active,
+	}, nil
+}

--- a/02-task-2-craftsbite/craftsbite_backend/internal/services/team_summary.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/services/team_summary.go
@@ -1,0 +1,166 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/sayad-ika/craftsbite/internal/repository"
+)
+
+type TeamSummary struct {
+	MemberCount int
+	MealCounts  map[string]int // meal_type -> opted-in count
+	WFHCount    int
+}
+
+type memberStatus struct {
+	meals    []repository.MealParticipation
+	location string
+}
+
+type memberData struct {
+	user     *repository.User
+	meals    []repository.MealParticipation
+	location *repository.WorkLocation
+}
+
+func fetchMemberData(ctx context.Context, client *dynamodb.Client, table, userID, date string) (memberData, error) {
+	var (
+		data    memberData
+		userErr error
+		mealErr error
+		locErr  error
+		wg      sync.WaitGroup
+	)
+
+	wg.Add(3)
+
+	go func() {
+		defer wg.Done()
+		data.user, userErr = repository.GetUserByID(ctx, client, table, userID)
+	}()
+
+	go func() {
+		defer wg.Done()
+		data.meals, mealErr = repository.GetParticipationsByUserDate(ctx, client, table, userID, date)
+	}()
+
+	go func() {
+		defer wg.Done()
+		data.location, locErr = repository.GetWorkLocation(ctx, client, table, userID, date)
+	}()
+
+	wg.Wait()
+
+	if userErr != nil {
+		return memberData{}, fmt.Errorf("user: %w", userErr)
+	}
+	if mealErr != nil {
+		return memberData{}, fmt.Errorf("meals: %w", mealErr)
+	}
+	if locErr != nil {
+		return memberData{}, fmt.Errorf("location: %w", locErr)
+	}
+
+	return data, nil
+}
+
+func buildMemberStatus(d memberData) memberStatus {
+	loc := "office"
+	if d.location != nil && d.location.Location != "" {
+		loc = d.location.Location
+	}
+	return memberStatus{
+		meals:    d.meals,
+		location: loc,
+	}
+}
+
+func GetTeamSummary(ctx context.Context, client *dynamodb.Client, table, teamID, date string) (*TeamSummary, error) {
+	members, err := repository.GetTeamMembers(ctx, client, table, teamID)
+	if err != nil {
+		return nil, fmt.Errorf("team_summary: members: %w", err)
+	}
+	if len(members) == 0 {
+		return &TeamSummary{MealCounts: make(map[string]int)}, nil
+	}
+
+	var (
+		availableMeals []string
+		mealsErr       error
+		statuses       = make([]memberStatus, len(members))
+		errs           = make([]error, len(members))
+		wg             sync.WaitGroup
+	)
+
+	wg.Add(1 + len(members))
+
+	go func() {
+		defer wg.Done()
+		availableMeals, mealsErr = repository.GetAvailableMeals(ctx, client, table, date)
+	}()
+
+	for i, m := range members {
+		i, m := i, m
+		go func() {
+			defer wg.Done()
+			data, err := fetchMemberData(ctx, client, table, m.UserID, date)
+			if err != nil {
+				errs[i] = fmt.Errorf("team_summary: member %s: %w", m.UserID, err)
+				return
+			}
+			statuses[i] = buildMemberStatus(data)
+		}()
+	}
+
+	wg.Wait()
+
+	if mealsErr != nil {
+		return nil, fmt.Errorf("team_summary: available meals: %w", mealsErr)
+	}
+	for _, e := range errs {
+		if e != nil {
+			return nil, e
+		}
+	}
+
+	seen := make(map[string]bool, len(availableMeals))
+	for _, mt := range availableMeals {
+		seen[mt] = true
+	}
+	if len(seen) == 0 {
+		for _, s := range statuses {
+			for _, p := range s.meals {
+				seen[p.MealType] = true
+			}
+		}
+	}
+
+	mealCounts := make(map[string]int, len(seen))
+	wfhCount := 0
+
+	for _, s := range statuses {
+		if s.location == "wfh" {
+			wfhCount++
+		}
+
+		mealByType := make(map[string]bool, len(s.meals))
+		for _, p := range s.meals {
+			mealByType[p.MealType] = p.IsParticipating
+		}
+
+		for mt := range seen {
+			if participating, ok := mealByType[mt]; !ok || participating {
+				mealCounts[mt]++
+			}
+		}
+	}
+
+	return &TeamSummary{
+		MemberCount: len(members),
+		MealCounts:  mealCounts,
+		WFHCount:    wfhCount,
+	}, nil
+}


### PR DESCRIPTION
Closes #46

### Dependencies

- #78   — `GetWorkLocation`, `GetParticipationsByUserDate`, `discord.SendFollowup`, `appconfig.MustLoad`, and the DynamoDB client singleton from `dynamo` are all reused.

### What does this PR do?

Implements the `/team-summary` slash command end-to-end: four new repository functions, `Team`/`TeamMember` domain types, a team-summary service with nested goroutine fan-out, and a complete replacement of the `cmd/management/main.go` stub.

### Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation

### What was changed

- **`internal/repository/types.go`** — Added `Team` and `TeamMember` domain structs; `teamMetadataItem` and `teamMemberItem` DynamoDB wire types.
- **`internal/repository/users.go`** — Added `time` import; added `GetUserByID`, `GetTeamByID`, `GetTeamMembers`, `FindTeamsByLeadID`.
- **`internal/services/team_summary.go`** — New file. `MemberStatus` struct. `GetTeamSummary` fetches member edges then fans out one goroutine per member; each member goroutine runs 3 inner goroutines with a shared `sync.Mutex`; results sorted by name.
- **`cmd/management/main.go`** — Replaced stub with a full native Lambda handler routing `team-summary` (implemented) and `override` (stub returning "coming soon"). `formatTeamSummary` produces a dynamic-width per-member table with totals footer; meal names title-cased from snake_case.

### Changelog

Feature: Team Leads can now run `/team-summary date:<YYYY-MM-DD>` in Discord to see a real-time per-member snapshot of meal participation and Office vs WFH status for their team. Admin and Logistics can query any team by passing `team_id`.

### How to Test

1. **Build check**: `go build ./cmd/management/`
2. **Service tests**: `go test ./internal/services/... -v`
3. **Join the test server** and run commands in `#1-meal-cmd-test`: <https://discord.gg/f5yhCxvP>

### How QA Should Test

> All commands go in **#1-meal-cmd-test** — replies are ephemeral.

| Command | Role | Expected Reply |
|---|---|---|
| `/team-summary date:2026-03-10` | team_lead | Per-member table for their team |
| `/team-summary date:2026-03-10 team_id:<uuid>` | admin | Per-member table for specified team |
| `/team-summary date:2026-03-10 team_id:<uuid>` | logistics | Same as admin — read-only |
| `/team-summary date:2026-03-10` | employee | "You do not have permission to use `/team-summary`." |
| `/team-summary date:2026-03-10` (lead, no team assigned) | team_lead | "You are not assigned to a team." |
| `/team-summary date:2026-03-10` (admin, no team_id) | admin | "Please provide a team_id…" |

### Rollback Plan

Revert this PR. The `team-summary` case reverts to the original stub returning an empty error. No schema changes — all queries use the existing `craftsbite` table and GSI1 index.

### Checklist

- [x] Code follows project style guidelines
- [x] Linting and type checks pass
- [x] All tests pass (`go build ./... ✓`)
- [x] Documentation updated (`technical_doc.md` updated in PR #1)

### Note for Reviewer

- (__none__)
