### PR TITLE
[PR-18] feat: consolidate `payload.CommandEvent`, Wire GChat Argument Adapter

### DIFF
--- a/02-task-2-craftsbite/craftsbite_backend/cmd/gchat-router/message.go
+++ b/02-task-2-craftsbite/craftsbite_backend/cmd/gchat-router/message.go
@@ -15,35 +15,12 @@ import (
 	"github.com/sayad-ika/craftsbite/internal/repository"
 )
 
-type CommandPayload struct {
-	UserID           string                 `json:"userID"`
-	Role             string                 `json:"role"`
-	CommandName      string                 `json:"commandName"`
-	Options          map[string]interface{} `json:"options"`
-	Source           string                 `json:"source"`
-	GChatSpaceName   string                 `json:"gchatSpaceName,omitempty"`
-	GChatMessageName string                 `json:"gchatMessageName,omitempty"`
-}
-
-var gchatCommandNames = map[int64]string{
-	1: "meal",
-	2: "location",
-	3: "team-summary",
-	4: "headcount",
-}
-
 func handleMessage(ctx context.Context, evt gchat.Event) (events.APIGatewayV2HTTPResponse, error) {
 	c := getConfig()
 
 	p := evt.Chat.AppCommandPayload
 	if p == nil {
 		return gchatText("Only slash commands are supported."), nil
-	}
-
-	commandID := int64(p.AppCommandMetadata.AppCommandID)
-	commandName, known := gchatCommandNames[commandID]
-	if !known {
-		return gchatText(fmt.Sprintf("Unknown command ID %d.", commandID)), nil
 	}
 
 	userID, role, err := repository.GetUserByGChatEmail(ctx, dynamo.GetClient(c), c.DynamoDBTable, evt.Chat.User.Email)
@@ -54,31 +31,22 @@ func handleMessage(ctx context.Context, evt gchat.Event) (events.APIGatewayV2HTT
 		return gchatText("Your Google Chat account is not linked to CraftsBite. Contact your admin."), nil
 	}
 
-	if !discord.CheckPermission(commandName, role) {
-		return gchatText(fmt.Sprintf("You do not have permission to use `/%s`.", commandName)), nil
+	cmdEvt, err := gchat.ToCommandEvent(evt, userID, role)
+	if err != nil {
+		return gchatText(err.Error()), nil
 	}
 
-	targetFn, ok := discord.Dispatch(c, commandName)
+	if !discord.CheckPermission(cmdEvt.CommandName, role) {
+		return gchatText(fmt.Sprintf("You do not have permission to use `/%s`.", cmdEvt.CommandName)), nil
+	}
+
+	targetFn, ok := discord.Dispatch(c, cmdEvt.CommandName)
 	if !ok || targetFn == "" {
-		log.Printf("gchat-router: no target function configured for command=%q", commandName)
-		return gchatText(fmt.Sprintf("Command `/%s` is not configured.", commandName)), nil
+		log.Printf("gchat-router: no target function configured for command=%q", cmdEvt.CommandName)
+		return gchatText(fmt.Sprintf("Command `/%s` is not configured.", cmdEvt.CommandName)), nil
 	}
 
-	var msgName string
-	if p.Message != nil {
-		msgName = p.Message.Name
-	}
-
-	payload := CommandPayload{
-		UserID:           userID,
-		Role:             role,
-		CommandName:      commandName,
-		Options:          map[string]interface{}{},
-		Source:           "gchat",
-		GChatSpaceName:   p.Space.Name,
-		GChatMessageName: msgName,
-	}
-	payloadBytes, err := json.Marshal(payload)
+	payloadBytes, err := json.Marshal(cmdEvt)
 	if err != nil {
 		return events.APIGatewayV2HTTPResponse{StatusCode: 500}, fmt.Errorf("gchat-router: marshal payload: %w", err)
 	}

--- a/02-task-2-craftsbite/craftsbite_backend/cmd/management/main.go
+++ b/02-task-2-craftsbite/craftsbite_backend/cmd/management/main.go
@@ -12,19 +12,10 @@ import (
 	appconfig "github.com/sayad-ika/craftsbite/internal/config"
 	"github.com/sayad-ika/craftsbite/internal/discord"
 	"github.com/sayad-ika/craftsbite/internal/dynamo"
+	"github.com/sayad-ika/craftsbite/internal/payload"
 	"github.com/sayad-ika/craftsbite/internal/repository"
 	"github.com/sayad-ika/craftsbite/internal/services"
 )
-
-type CommandEvent struct {
-	UserID           string                 `json:"userID"`
-	Role             string                 `json:"role"`
-	DiscordID        string                 `json:"discordId"`
-	CommandName      string                 `json:"commandName"`
-	Options          map[string]interface{} `json:"options"`
-	InteractionToken string                 `json:"interactionToken"`
-	ApplicationID    string                 `json:"applicationId"`
-}
 
 var (
 	cfgOnce sync.Once
@@ -38,7 +29,7 @@ func getConfig() *appconfig.Config {
 	return cfg
 }
 
-func handler(ctx context.Context, event CommandEvent) error {
+func handler(ctx context.Context, event payload.CommandEvent) error {
 	c := getConfig()
 	client := dynamo.GetClient(c)
 
@@ -56,7 +47,7 @@ func handler(ctx context.Context, event CommandEvent) error {
 	return discord.SendFollowup(event.ApplicationID, event.InteractionToken, replyContent)
 }
 
-func handleTeamSummary(ctx context.Context, client *dynamodb.Client, table string, event CommandEvent) string {
+func handleTeamSummary(ctx context.Context, client *dynamodb.Client, table string, event payload.CommandEvent) string {
 	if event.Role != "team_lead" && event.Role != "admin" {
 		return "You do not have permission to use `/team-summary`."
 	}

--- a/02-task-2-craftsbite/craftsbite_backend/cmd/ops/main.go
+++ b/02-task-2-craftsbite/craftsbite_backend/cmd/ops/main.go
@@ -12,18 +12,9 @@ import (
 	appconfig "github.com/sayad-ika/craftsbite/internal/config"
 	"github.com/sayad-ika/craftsbite/internal/discord"
 	"github.com/sayad-ika/craftsbite/internal/dynamo"
+	"github.com/sayad-ika/craftsbite/internal/payload"
 	"github.com/sayad-ika/craftsbite/internal/services"
 )
-
-type CommandEvent struct {
-	UserID           string                 `json:"userID"`
-	Role             string                 `json:"role"`
-	DiscordID        string                 `json:"discordId"`
-	CommandName      string                 `json:"commandName"`
-	Options          map[string]interface{} `json:"options"`
-	InteractionToken string                 `json:"interactionToken"`
-	ApplicationID    string                 `json:"applicationId"`
-}
 
 var (
 	cfgOnce sync.Once
@@ -37,7 +28,7 @@ func getConfig() *appconfig.Config {
 	return cfg
 }
 
-func handler(ctx context.Context, event CommandEvent) error {
+func handler(ctx context.Context, event payload.CommandEvent) error {
 	c := getConfig()
 	client := dynamo.GetClient(c)
 
@@ -57,7 +48,7 @@ func handler(ctx context.Context, event CommandEvent) error {
 	return discord.SendFollowup(event.ApplicationID, event.InteractionToken, replyContent)
 }
 
-func handleHeadcount(ctx context.Context, client *dynamodb.Client, table string, event CommandEvent) string {
+func handleHeadcount(ctx context.Context, client *dynamodb.Client, table string, event payload.CommandEvent) string {
 	if event.Role != "admin" && event.Role != "logistics" {
 		return "You do not have permission to use `/headcount`."
 	}

--- a/02-task-2-craftsbite/craftsbite_backend/cmd/self/main.go
+++ b/02-task-2-craftsbite/craftsbite_backend/cmd/self/main.go
@@ -12,18 +12,9 @@ import (
 	appconfig "github.com/sayad-ika/craftsbite/internal/config"
 	"github.com/sayad-ika/craftsbite/internal/discord"
 	"github.com/sayad-ika/craftsbite/internal/dynamo"
+	"github.com/sayad-ika/craftsbite/internal/payload"
 	"github.com/sayad-ika/craftsbite/internal/services"
 )
-
-type CommandEvent struct {
-	UserID           string                 `json:"userID"`
-	Role             string                 `json:"role"`
-	DiscordID        string                 `json:"discordId"`
-	CommandName      string                 `json:"commandName"`
-	Options          map[string]interface{} `json:"options"`
-	InteractionToken string                 `json:"interactionToken"`
-	ApplicationID    string                 `json:"applicationId"`
-}
 
 var validMealOptions = map[string]bool{
 	"lunch":           true,
@@ -45,7 +36,7 @@ func getConfig() *appconfig.Config {
 	return cfg
 }
 
-func handler(ctx context.Context, event CommandEvent) error {
+func handler(ctx context.Context, event payload.CommandEvent) error {
 	c := getConfig()
 	client := dynamo.GetClient(c)
 
@@ -65,7 +56,7 @@ func handler(ctx context.Context, event CommandEvent) error {
 	return discord.SendFollowup(event.ApplicationID, event.InteractionToken, replyContent)
 }
 
-func handleLocation(ctx context.Context, client *dynamodb.Client, table string, event CommandEvent) string {
+func handleLocation(ctx context.Context, client *dynamodb.Client, table string, event payload.CommandEvent) string {
 	date, ok := optString(event.Options, "date")
 	if !ok || date == "" {
 		return "Please provide a date. Example: `/location date:2026-03-10 location:office`"
@@ -86,7 +77,7 @@ func handleLocation(ctx context.Context, client *dynamodb.Client, table string, 
 	return formatLocationStatus(date, wl.Location, mealStatuses)
 }
 
-func handleMeal(ctx context.Context, client *dynamodb.Client, table string, event CommandEvent) string {
+func handleMeal(ctx context.Context, client *dynamodb.Client, table string, event payload.CommandEvent) string {
 	date, ok := optString(event.Options, "date")
 	if !ok || date == "" {
 		return "Please provide a date. Example: `/meal date:2026-03-10 status:out`"

--- a/02-task-2-craftsbite/craftsbite_backend/internal/gchat/adapter.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/gchat/adapter.go
@@ -1,0 +1,131 @@
+package gchat
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/sayad-ika/craftsbite/internal/payload"
+)
+
+var gchatCommandNames = map[int64]string{
+	1: "meal",
+	2: "location",
+	3: "team-summary",
+	4: "headcount",
+}
+
+func ToCommandEvent(evt Event, internalUserID, role string) (payload.CommandEvent, error) {
+	p := evt.Chat.AppCommandPayload
+	if p == nil {
+		return payload.CommandEvent{}, fmt.Errorf("appCommandPayload is nil")
+	}
+
+	commandID := int64(p.AppCommandMetadata.AppCommandID)
+	commandName, known := gchatCommandNames[commandID]
+	if !known {
+		return payload.CommandEvent{}, fmt.Errorf("unknown command ID %d", commandID)
+	}
+
+	var argText string
+	var msgName string
+	if p.Message != nil {
+		argText = p.Message.ArgumentText
+		msgName = p.Message.Name
+	}
+
+	var opts map[string]interface{}
+	var err error
+
+	switch commandID {
+	case 1:
+		opts, err = parseMealArgs(argText)
+		if err != nil {
+			return payload.CommandEvent{}, err
+		}
+	case 2:
+		opts = parseLocationArgs(argText)
+	case 3:
+		opts = parseDateArg(argText)
+	case 4:
+		opts = parseDateArg(argText)
+	}
+
+	return payload.CommandEvent{
+		UserID:           internalUserID,
+		Role:             role,
+		CommandName:      commandName,
+		Options:          opts,
+		Source:           "gchat",
+		GChatSpaceName:   p.Space.Name,
+		GChatMessageName: msgName,
+	}, nil
+}
+
+func parseMealArgs(raw string) (map[string]interface{}, error) {
+	tokens := strings.Fields(raw)
+	if len(tokens) == 0 {
+		return nil, fmt.Errorf("usage: /meal <in|out> [meal_type] [YYYY-MM-DD]")
+	}
+
+	status := strings.ToLower(tokens[0])
+	if status != "in" && status != "out" {
+		return nil, fmt.Errorf("usage: /meal <in|out> [meal_type] [YYYY-MM-DD]")
+	}
+
+	mealType := "all"
+	if len(tokens) > 1 {
+		mealType = strings.ToLower(tokens[1])
+	}
+
+	date := todayDhaka()
+	if len(tokens) > 2 {
+		date = tokens[2]
+	}
+
+	return map[string]interface{}{
+		"status": status,
+		"meal":   mealType,
+		"date":   date,
+	}, nil
+}
+
+func parseLocationArgs(raw string) map[string]interface{} {
+	tokens := strings.Fields(raw)
+
+	loc := ""
+	if len(tokens) > 0 {
+		loc = strings.ToLower(tokens[0])
+	}
+
+	date := todayDhaka()
+	if len(tokens) > 1 {
+		date = tokens[1]
+	}
+
+	return map[string]interface{}{
+		"location": loc,
+		"date":     date,
+	}
+}
+
+func parseDateArg(raw string) map[string]interface{} {
+	tokens := strings.Fields(raw)
+
+	date := todayDhaka()
+	if len(tokens) > 0 {
+		date = tokens[0]
+	}
+
+	return map[string]interface{}{
+		"date": date,
+	}
+}
+
+func todayDhaka() string {
+	loc, err := time.LoadLocation("Asia/Dhaka")
+	if err != nil {
+		loc = time.UTC
+	}
+	return time.Now().In(loc).Format("2006-01-02")
+}

--- a/02-task-2-craftsbite/craftsbite_backend/internal/gchat/card.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/gchat/card.go
@@ -1,0 +1,103 @@
+package gchat
+
+import (
+	"encoding/json"
+)
+
+type CardResponse struct {
+	CardsV2 []CardV2Wrapper `json:"cardsV2"`
+}
+
+type CardV2Wrapper struct {
+	CardID string `json:"cardId"`
+	Card   CardV2 `json:"card"`
+}
+
+type CardV2 struct {
+	Header   *CardHeader   `json:"header,omitempty"`
+	Sections []CardSection `json:"sections"`
+}
+
+type CardHeader struct {
+	Title    string `json:"title"`
+	Subtitle string `json:"subtitle,omitempty"`
+}
+
+type CardSection struct {
+	Widgets []CardWidget `json:"widgets"`
+}
+
+type CardWidget struct {
+	TextParagraph *TextParagraph `json:"textParagraph,omitempty"`
+	DecoratedText *DecoratedText `json:"decoratedText,omitempty"`
+}
+
+type TextParagraph struct {
+	Text string `json:"text"`
+}
+
+type DecoratedText struct {
+	TopLabel string `json:"topLabel"`
+	Text     string `json:"text"`
+}
+
+func SimpleTextCard(text string) ([]byte, error) {
+	resp := CardResponse{
+		CardsV2: []CardV2Wrapper{
+			{
+				CardID: "response",
+				Card: CardV2{
+					Sections: []CardSection{
+						{
+							Widgets: []CardWidget{
+								{
+									TextParagraph: &TextParagraph{Text: text},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return json.Marshal(resp)
+}
+
+func LocationCard(location, date, mealStatus string) ([]byte, error) {
+	resp := CardResponse{
+		CardsV2: []CardV2Wrapper{
+			{
+				CardID: "location-response",
+				Card: CardV2{
+					Header: &CardHeader{
+						Title:    "Location Set",
+						Subtitle: date,
+					},
+					Sections: []CardSection{
+						{
+							Widgets: []CardWidget{
+								{
+									DecoratedText: &DecoratedText{
+										TopLabel: "Work location",
+										Text:     location,
+									},
+								},
+							},
+						},
+						{
+							Widgets: []CardWidget{
+								{
+									DecoratedText: &DecoratedText{
+										TopLabel: "Meal status",
+										Text:     mealStatus,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return json.Marshal(resp)
+}

--- a/02-task-2-craftsbite/craftsbite_backend/internal/gchat/event.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/gchat/event.go
@@ -26,6 +26,7 @@ type Message struct {
 	Name         string        `json:"name"`
 	Sender       Sender        `json:"sender"`
 	Text         string        `json:"text"`
+	ArgumentText string        `json:"argumentText"`
 	SlashCommand *SlashCommand `json:"slashCommand,omitempty"`
 }
 

--- a/02-task-2-craftsbite/craftsbite_backend/internal/payload/payload.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/payload/payload.go
@@ -1,0 +1,14 @@
+package payload
+
+type CommandEvent struct {
+	UserID           string                 `json:"userID"`
+	Role             string                 `json:"role"`
+	DiscordID        string                 `json:"discordId"`
+	CommandName      string                 `json:"commandName"`
+	Options          map[string]interface{} `json:"options"`
+	InteractionToken string                 `json:"interactionToken"`
+	ApplicationID    string                 `json:"applicationId"`
+	Source           string                 `json:"source"`
+	GChatSpaceName   string                 `json:"gchatSpaceName,omitempty"`
+	GChatMessageName string                 `json:"gchatMessageName,omitempty"`
+}


### PR DESCRIPTION
<!-- Link to the issue this PR addresses -->
Closes #48 

### Dependencies

- #83 

### What does this PR do?

Eliminates four duplicate payload struct definitions, wires argument parsing into the GChat router so command Lambdas receive populated `Options` from Google Chat, and adds a Card v2 response builder for structured replies.

### Type of Change

- [x] New feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation

### What was changed

- **`internal/payload/payload.go`** _(new)_ — single `CommandEvent` struct with 10 fields: `UserID`, `Role`, `DiscordID`, `CommandName`, `Options`, `InteractionToken`, `ApplicationID`, `Source`, `GChatSpaceName`, `GChatMessageName`. Placed under `internal/payload/` rather than per-package because it is the contract between routers and command Lambdas — a single source of truth prevents field drift and makes adding new fields (e.g. for a future web frontend) a one-line change.
- **`cmd/self/main.go`** — removed local `CommandEvent` (7 fields), imported `internal/payload`, replaced all references with `payload.CommandEvent`. No handler logic changed.
- **`cmd/management/main.go`** — same migration as `cmd/self`.
- **`cmd/ops/main.go`** — same migration as `cmd/self`.
- **`cmd/gchat-router/message.go`** — removed local `CommandPayload` (7 fields) and `gchatCommandNames` map. `handleMessage` now calls `gchat.ToCommandEvent(evt, userID, role)` which returns a fully populated `payload.CommandEvent` with parsed arguments. Errors from `ToCommandEvent` (unknown command ID, invalid `/meal` arguments) are caught and returned as `gchatText(err.Error())` — the Lambda is NOT invoked when argument parsing fails. Manual assignments of `Source`, `GChatSpaceName`, `GChatMessageName` removed — `ToCommandEvent` sets these internally.
- **`internal/gchat/event.go`** — added `ArgumentText string` field to `Message` struct. This is the field Google Chat populates with the free-text portion after the slash command name.
- **`internal/gchat/adapter.go`** _(new)_ — `ToCommandEvent` dispatches on `AppCommandID`: 1→`parseMealArgs`, 2→`parseLocationArgs`, 3→`parseDateArg`, 4→`parseDateArg`. `parseMealArgs` validates status (`in`/`out`) and returns an error with usage instructions on failure. `parseLocationArgs` and `parseDateArg` default date to `todayDhaka()` (Asia/Dhaka timezone, UTC fallback) — the `/location` handler rejects empty dates so the adapter always injects one.
- **`internal/gchat/card.go`** _(new)_ — Card v2 types (`CardResponse`, `CardV2Wrapper`, `CardV2`, `CardHeader`, `CardSection`, `CardWidget`, `TextParagraph`, `DecoratedText`) and two builders: `SimpleTextCard` (single text paragraph) and `LocationCard` (header + two decorated-text sections for location and meal status).

### Changelog

Refactor: Consolidated four duplicate payload structs into `internal/payload/CommandEvent`. Feature: GChat argument adapter (`ToCommandEvent`) parses free-text arguments for all four commands with input validation. Feature: Card v2 JSON response builder (`SimpleTextCard`, `LocationCard`).

### How to Test

1. **Build check**: `go build ./...` — zero errors expected.
2. **Unit tests**: `go test ./internal/gchat/... -v` — covers `ToCommandEvent` for all command IDs, argument parsing edge cases, and card JSON output.
3. **Integration**: Deploy all four changed Lambdas and issue `/meal in lunch` in Google Chat — the `self` Lambda should receive populated `Options` instead of an empty map.

### Rollback Plan

Restore the four local struct definitions in each `cmd/` package. Delete `internal/payload/payload.go`, `internal/gchat/adapter.go`, and `internal/gchat/card.go`. Remove `ArgumentText` from `Message` in `event.go`. Run `go build ./...`.

### Checklist

- [x] Code follows project style guidelines (mirrors `cmd/router/main.go` and `internal/discord/dispatch.go` idioms)
- [x] All packages build (`go build ./... ✓`)
- [] Documentation updated

---