### PR TITLE
[PR-23] doc: update technical documentation for schedule-day command

### DIFF
--- a/02-task-2-craftsbite/docs/technical_doc.md
+++ b/02-task-2-craftsbite/docs/technical_doc.md
@@ -318,7 +318,7 @@ Enriched payload: `userID`, `role`, `email`, `commandName`, `argumentText`, `rep
 | `override`     | `management`  | `LAMBDA_MANAGEMENT_FUNCTION_NAME` |
 | `team-summary` | `management`  | `LAMBDA_MANAGEMENT_FUNCTION_NAME` |
 | `headcount`    | `ops`         | `LAMBDA_OPS_FUNCTION_NAME`        |
-| `set-day`      | `ops`         | `LAMBDA_OPS_FUNCTION_NAME`        |
+| `schedule-day` | `ops`         | `LAMBDA_OPS_FUNCTION_NAME`        |
 | `admin`        | `ops`         | `LAMBDA_OPS_FUNCTION_NAME`        |
 
 ---
@@ -335,20 +335,21 @@ Enriched payload: `userID`, `role`, `email`, `commandName`, `argumentText`, `rep
 | `/override`     | `date` (req), `user` (req), `meal` (req: `lunch\|snacks\|iftar\|event_dinner\|optional_dinner`), `status` (req: `in\|out`), `reason` (opt)                                  | Team Leads: own team only. Admin: any user. Bypasses cutoff; meal must be available for the date.                                                                                                                                                                                                         |
 | `/team-summary` | `date` (req), `team_id` (opt)                                                                                                                                               | Team Leads: own team only (ignores `team_id`). Logistics: read-only, any team. Admin: any team.                                                                                                                                                                                                           |
 | `/headcount`    | `date` (req)                                                                                                                                                                | Admin and Logistics only. Returns meal totals and Office vs WFH split for the date. Users with no work location record are counted as office.                                                                                                                                                             |
-| `/set-day`      | `date` (req), `day_status` (req: `normal\|office_closed\|govt_holiday\|celebration\|event_day`), `meals` (opt: comma-separated meal types), `note` (opt)                    | Admin only. Setting `office_closed` or `govt_holiday` forces `meals` to empty.                                                                                                                                                                                                                            |
+| `/schedule-day` | `date` (req), `status` (req: `normal\|office_closed\|govt_holiday\|celebration\|weekend\|event_day`), `meals` (opt: comma-separated meal types), `reason` (opt)             | Admin only. Setting `office_closed` or `govt_holiday` forces `meals` to empty.                                                                                                                                                                                                                            |
 | `/admin`        | `action` (req: `create-user\|update-role\|deactivate-user\|create-team\|add-member\|remove-member`), plus action-specific options                                           | Admin only.                                                                                                                                                                                                                                                                                               |
 
 ### Google Chat
 
-Google Chat uses free-text argument strings. Arguments are positional and parsed by the GChat Router Lambda before invoking the command Lambda. Only the five commands below are registered — `/override`, `/set-day`, and `/admin` are not exposed until their handlers are ready for the platform.
+Google Chat uses free-text argument strings. Arguments are positional and parsed by the GChat Router Lambda before invoking the command Lambda. The six commands below are registered — `/override` and `/admin` are not exposed until their handlers are ready for the platform.
 
-| Command         | Command ID | Argument format                | Notes                                                                                                                                                                 |
-| --------------- | ---------- | ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `/meal`         | 1          | `<in\|out> <meal_type> [date]` | `meal_type` required (no day-wide fan-out via omission on GChat). `date` defaults to today if omitted. `iftar` is not exposed — parity with what the handler accepts. |
-| `/location`     | 2          | `<office\|wfh> [date]`         | `date` defaults to today if omitted.                                                                                                                                  |
-| `/team-summary` | 3          | `[date]`                       | `date` defaults to today if omitted. `team_id` is not advertised — handler always uses the caller's first led team.                                                   |
-| `/headcount`    | 4          | `<date>`                       | `date` is required. Router returns a usage hint card before invoking Lambda if omitted.                                                                               |
-| `/status`       | 5          | `[date]`                       | `date` defaults to tomorrow if omitted. Read-only — no database writes.                                                                                               |
+| Command         | Command ID | Argument format                    | Notes                                                                                                                                                                 |
+| --------------- | ---------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/meal`         | 1          | `<in\|out> <meal_type> [date]`     | `meal_type` required (no day-wide fan-out via omission on GChat). `date` defaults to today if omitted. `iftar` is not exposed — parity with what the handler accepts. |
+| `/location`     | 2          | `<office\|wfh> [date]`             | `date` defaults to today if omitted.                                                                                                                                  |
+| `/team-summary` | 3          | `[date]`                           | `date` defaults to today if omitted. `team_id` is not advertised — handler always uses the caller's first led team.                                                   |
+| `/headcount`    | 4          | `<date>`                           | `date` is required. Router returns a usage hint card before invoking Lambda if omitted.                                                                               |
+| `/status`       | 5          | `[date]`                           | `date` defaults to tomorrow if omitted. Read-only — no database writes.                                                                                               |
+| `/schedule-day` | 6          | `<date> <status> [meals] [reason]` | Admin only. `date` in YYYY-MM-DD format. `meals` comma-separated. `reason` is free text (all remaining words).                                                        |
 
 ---
 
@@ -486,6 +487,37 @@ Bob Smith      │ Lunch ✓  │ Snacks ✓  │ WFH
 Carol Lee      │ Lunch ✗  │ Snacks ✗  │ Office
 ──────────────────────────────────────
 Totals: Lunch 2/3  │  Snacks 1/3  │  WFH 1/3
+```
+
+---
+
+### `/schedule-day`
+
+```
+/schedule-day date:<YYYY-MM-DD|range> status:<normal|office_closed|govt_holiday|celebration|weekend|event_day> [meals:<comma-separated>] [reason:<text>]
+```
+
+Sets the day schedule and available meals for one or more dates. Available to `admin` role only.
+
+#### Single-date usage
+
+Passes a single `YYYY-MM-DD` date. The schedule is created or updated for that date immediately.
+
+| Scenario                             | Reply                                                                  |
+| ------------------------------------ | ---------------------------------------------------------------------- |
+| Success                              | `✓ Day schedule set for <date>` with status, meals, and reason summary |
+| Invalid date format                  | `Invalid date format. Use YYYY-MM-DD (e.g., 2026-03-25)`               |
+| Invalid status value                 | `invalid day status: <value> (valid: [...])`                           |
+| office_closed / govt_holiday + meals | `office_closed and govt_holiday days cannot have meals.`               |
+| Wrong role                           | `You do not have permission to use /schedule-day.`                     |
+
+**Example reply:**
+
+```
+✓ Day schedule set for 2026-03-27
+
+**Status**: 📅 Normal Day
+**Meals**: Lunch, Snacks, Iftar
 ```
 
 ---

--- a/02-task-2-craftsbite/docs/technical_doc.md
+++ b/02-task-2-craftsbite/docs/technical_doc.md
@@ -69,7 +69,7 @@ Discord Router Lambda                     GChat Router Lambda
                         |  management -- /override, /team-summary        (team_lead, admin, logistics)
                         |  `/team-summary` fan-out: one goroutine per member fetches meals + location
                         |
-                        |  ops        -- /headcount, /set-day, /admin    (admin, logistics)
+                        |  ops        -- /headcount, /schedule-day, /admin    (admin, logistics)
                         |  `/headcount` runs 3 parallel GSI1 queries, joins in memory
                         |
                         |  receives pre-verified event with caller identity + Source attached
@@ -122,12 +122,12 @@ Discord Router Lambda                     GChat Router Lambda
 
 **Role-based behavior**
 
-| Role      | `/meal` `/location` `/status` | `/override`   | `/team-summary`       | `/headcount`  | `/set-day` | `/admin` |
-| --------- | ----------------------------- | ------------- | --------------------- | ------------- | ---------- | -------- |
-| Employee  | Own records only              | ✗             | ✗                     | ✗             | ✗          | ✗        |
-| Team Lead | Own records only              | Own team only | Own team only         | ✗             | ✗          | ✗        |
-| Logistics | Own records only              | ✗             | Read-only (all teams) | ✓ (read-only) | ✗          | ✗        |
-| Admin     | Own records only              | Any user      | All teams             | ✓             | ✓          | ✓        |
+| Role      | `/meal` `/location` `/status` | `/override`   | `/team-summary`       | `/headcount`  | `/schedule-day` | `/admin` |
+| --------- | ----------------------------- | ------------- | --------------------- | ------------- | --------------- | -------- |
+| Employee  | Own records only              | ✗             | ✗                     | ✗             | ✗               | ✗        |
+| Team Lead | Own records only              | Own team only | Own team only         | ✗             | ✗               | ✗        |
+| Logistics | Own records only              | ✗             | Read-only (all teams) | ✓ (read-only) | ✗               | ✗        |
+| Admin     | Own records only              | Any user      | All teams             | ✓             | ✓               | ✓        |
 
 **Validation rules**
 
@@ -250,7 +250,7 @@ Each Lambda is compiled to a separate static binary named `bootstrap` (Lambda cu
 - **GChat Router Lambda** — compiled from `cmd/gchat-router/main.go`, deployed as its own function, invoked by API Gateway (`POST /gchat`) on every Google Chat interaction. Uses `internal/gchat/` (`event.go` — event types; `card.go` — Card v2 builder; `reply.go` — Chat REST API reply). Reuses `internal/discord/dispatch.go` for ACL checks and Lambda dispatch. Resolves callers by Google Workspace email (`PK=GCHAT#<email>`, `SK=LOOKUP`).
 - **`self` Lambda** — compiled from `cmd/self/main.go`, handles `/meal`, `/location`, `/status` — available to all roles
 - **`management` Lambda** — compiled from `cmd/management/main.go`, handles `/override`, `/team-summary` — available to `team_lead`, `admin`, and `logistics` (read-only)
-- **`ops` Lambda** — compiled from `cmd/ops/main.go`, handles `/headcount`, `/set-day`, `/admin` — available to `admin` and `logistics` (headcount only)
+- **`ops` Lambda** — compiled from `cmd/ops/main.go`, handles `/headcount`, `/schedule-day`, `/admin` — available to `admin` and `logistics` (headcount only)
 
 Local development runs each binary directly as a standalone executable — no adapter or environment detection required.
 

--- a/02-task-2-craftsbite/docs/technical_doc.md
+++ b/02-task-2-craftsbite/docs/technical_doc.md
@@ -520,4 +520,32 @@ Passes a single `YYYY-MM-DD` date. The schedule is created or updated for that d
 **Meals**: Lunch, Snacks, Iftar
 ```
 
+#### Bulk scheduling
+
+Passes a date range (`YYYY-MM-DD..YYYY-MM-DD`) or the `week` keyword (next 5 business days from tomorrow).
+
+**Weekend skipping:** Saturdays and Sundays within the range are silently skipped — no record is created, no error is raised for those specific days. The reply note states that weekend dates were skipped.
+
+**Atomicity:** All weekday writes in the batch succeed together or none do. If any single-date write fails (e.g. invalid meal type, DynamoDB error), every record already written in that batch is deleted before the error is returned to the user.
+
+**Max range:** 14 days (shared with `/meal` and `/location`).
+
+| Scenario                   | Reply                                                                                   |
+| -------------------------- | --------------------------------------------------------------------------------------- |
+| Success                    | `✓ Day schedule set to <status> for N weekday(s):` + bullet list + weekend-skipped note |
+| All dates are weekends     | `All dates in the specified range fall on weekends. No schedule was set.`               |
+| Start date after end date  | `Invalid date: end date X is before start date Y`                                       |
+| Range exceeds 14 days      | `Invalid date: date range too large: N days (max 14 days)`                              |
+| Any write fails (rollback) | `Bulk schedule failed (no changes saved): failed on <date>: <reason>`                   |
+
+**Example reply (bulk success):**
+
+```
+✓ Day schedule set to 📅 Normal Day for 3 weekday(s):
+  • 2026-04-07
+  • 2026-04-08
+  • 2026-04-09
+_(Weekend dates in the range were automatically skipped.)_
+```
+
 ---


### PR DESCRIPTION
Closes #52, #53

## Dependencies

- #88 

## What does this PR do?

Updates `technical_doc.md` to document the `/schedule-day` command (renamed from `/set-day`), including the new `weekend` status option, updated parameter names, and Google Chat support — and extends it further to cover bulk date-range scheduling, the `YYYY-MM-DD..YYYY-MM-DD` and `week` range syntax, weekend-skipping rule, atomicity behaviour, and the all-weekend error case.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation

## What was changed

- **§4 (Cloud Architecture diagram)** — updated ops Lambda description from `/set-day` to `/schedule-day`.

- **§6 (Requirements) — Role-based behavior table** — renamed `/set-day` column header to `/schedule-day`.

- **§10 (Deployment)** — updated ops Lambda description from `/set-day` to `/schedule-day`.

- **§15 (Router Dispatch Table)** — renamed `set-day` command to `schedule-day` in the dispatch mapping.

- **§16 (Registered Slash Commands) — Discord table** — renamed `/set-day` to `/schedule-day`; changed `day_status` parameter to `status`; changed `note` parameter to `reason`; added `weekend` to the list of valid status choices (now 6 options: `normal`, `office_closed`, `govt_holiday`, `celebration`, `weekend`, `event_day`); updated the `date` option to document range support (`YYYY-MM-DD..YYYY-MM-DD`, `week`); extended Notes column to describe weekend skipping, atomicity, 14-day max, and all-weekend error.

- **§16 (Registered Slash Commands) — Google Chat intro** — updated from "five commands" to "six commands" and removed `/schedule-day` from the not-yet-exposed exclusion list. Added `/schedule-day` as command ID 6 with argument format `<date> <status> [meals] [reason]` and admin-only access note.

- **§17 (Command Usage) — new `/schedule-day` sub-section** — added full command usage block with single-date and bulk scheduling sub-sections; scenario/reply tables for both paths covering success, all-weekend error, invalid range, range-too-large, and rollback cases; annotated example reply for bulk success.

## Changelog

None: not user visible

## How to Test

_(none_needed)_

## How QA Should Test

Not applicable — documentation only.

## Rollback Plan

No rollback needed — documentation change only.

## Checklist

- [ ] My code follows the project style guidelines
- [ ] Code passes linting and type checks
- [ ] All tests pass
- [ ] I have added tests for my changes (if applicable)
- [x] I have updated documentation (if applicable)