### PR TITLE
[PR-31] refactor: dependency injection, global state removal, and shared cmdutil extraction

### DIFF
--- a/02-task-2-craftsbite/craftsbite_backend/cmd/gchat-router/main.go
+++ b/02-task-2-craftsbite/craftsbite_backend/cmd/gchat-router/main.go
@@ -6,48 +6,28 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"sync"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	lambdaclient "github.com/aws/aws-sdk-go-v2/service/lambda"
 	appconfig "github.com/sayad-ika/craftsbite/internal/config"
+	"github.com/sayad-ika/craftsbite/internal/dynamo"
 	"github.com/sayad-ika/craftsbite/internal/gchat"
 )
 
-var (
-	cfgOnce    sync.Once
-	cfg        *appconfig.Config
-	lambdaOnce sync.Once
-	lc         *lambdaclient.Client
-)
-
-func getConfig() *appconfig.Config {
-	cfgOnce.Do(func() {
-		cfg = appconfig.MustLoad()
-	})
-	return cfg
-}
-
-func newLambdaClient(c *appconfig.Config) *lambdaclient.Client {
+func newLambdaClient(c *appconfig.Config) (*lambdaclient.Client, error) {
 	awscfg, err := awsconfig.LoadDefaultConfig(context.Background(),
 		awsconfig.WithRegion(c.AWSRegion),
 	)
 	if err != nil {
-		panic(fmt.Sprintf("gchat-router: failed to load AWS config: %v", err))
+		return nil, fmt.Errorf("gchat-router: failed to load AWS config: %w", err)
 	}
-	return lambdaclient.NewFromConfig(awscfg)
+	return lambdaclient.NewFromConfig(awscfg), nil
 }
 
-func getLambdaClient() *lambdaclient.Client {
-	lambdaOnce.Do(func() {
-		lc = newLambdaClient(getConfig())
-	})
-	return lc
-}
-
-func handler(ctx context.Context, req events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
+func handler(ctx context.Context, cfg *appconfig.Config, client *dynamodb.Client, lambdaClient *lambdaclient.Client, req events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
 	if err := verifyGChatToken(ctx, req.Headers["authorization"]); err != nil {
 		log.Printf("gchat-router: JWT verification failed: %v", err)
 		return events.APIGatewayV2HTTPResponse{StatusCode: 401}, nil
@@ -70,7 +50,7 @@ func handler(ctx context.Context, req events.APIGatewayV2HTTPRequest) (events.AP
 	}
 
 	if evt.Chat.AppCommandPayload != nil {
-		resp, err := handleMessage(ctx, evt)
+		resp, err := handleMessage(ctx, cfg, client, lambdaClient, evt)
 		if err != nil {
 			log.Printf("gchat-router: handleMessage: %v", err)
 			return gchatText("An error occurred. Please try again.", evt.Chat.User.Name), nil
@@ -86,5 +66,17 @@ func ok(body string) (events.APIGatewayV2HTTPResponse, error) {
 }
 
 func main() {
-	lambda.Start(handler)
+	cfg := appconfig.MustLoad()
+	client, err := dynamo.NewClient(cfg)
+	if err != nil {
+		log.Fatalf("gchat-router: %v", err)
+	}
+	lambdaClient, err := newLambdaClient(cfg)
+	if err != nil {
+		log.Fatalf("gchat-router: %v", err)
+	}
+
+	lambda.Start(func(ctx context.Context, req events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
+		return handler(ctx, cfg, client, lambdaClient, req)
+	})
 }

--- a/02-task-2-craftsbite/craftsbite_backend/cmd/gchat-router/message.go
+++ b/02-task-2-craftsbite/craftsbite_backend/cmd/gchat-router/message.go
@@ -7,16 +7,16 @@ import (
 	"log"
 
 	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	lambdaclient "github.com/aws/aws-sdk-go-v2/service/lambda"
 	"github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	appconfig "github.com/sayad-ika/craftsbite/internal/config"
 	"github.com/sayad-ika/craftsbite/internal/discord"
-	"github.com/sayad-ika/craftsbite/internal/dynamo"
 	"github.com/sayad-ika/craftsbite/internal/gchat"
 	"github.com/sayad-ika/craftsbite/internal/repository"
 )
 
-func handleMessage(ctx context.Context, evt gchat.Event) (events.APIGatewayV2HTTPResponse, error) {
-	c := getConfig()
+func handleMessage(ctx context.Context, cfg *appconfig.Config, client *dynamodb.Client, lambdaClient *lambdaclient.Client, evt gchat.Event) (events.APIGatewayV2HTTPResponse, error) {
 	viewerName := evt.Chat.User.Name
 
 	p := evt.Chat.AppCommandPayload
@@ -24,7 +24,7 @@ func handleMessage(ctx context.Context, evt gchat.Event) (events.APIGatewayV2HTT
 		return gchatText("Only slash commands are supported.", viewerName), nil
 	}
 
-	userID, role, err := repository.GetUserByGChatEmail(ctx, dynamo.GetClient(c), c.DynamoDBTable, evt.Chat.User.Email)
+	userID, role, err := repository.GetUserByGChatEmail(ctx, client, cfg.DynamoDBTable, evt.Chat.User.Email)
 	if err != nil {
 		return events.APIGatewayV2HTTPResponse{StatusCode: 500}, fmt.Errorf("gchat-router: identity resolution: %w", err)
 	}
@@ -41,7 +41,7 @@ func handleMessage(ctx context.Context, evt gchat.Event) (events.APIGatewayV2HTT
 		return gchatText(fmt.Sprintf("You do not have permission to use `/%s`.", cmdEvt.CommandName), viewerName), nil
 	}
 
-	targetFn, ok := discord.Dispatch(c, cmdEvt.CommandName)
+	targetFn, ok := discord.Dispatch(cfg, cmdEvt.CommandName)
 	if !ok || targetFn == "" {
 		log.Printf("gchat-router: no target function configured for command=%q", cmdEvt.CommandName)
 		return gchatText(fmt.Sprintf("Command `/%s` is not configured.", cmdEvt.CommandName), viewerName), nil
@@ -52,7 +52,7 @@ func handleMessage(ctx context.Context, evt gchat.Event) (events.APIGatewayV2HTT
 		return events.APIGatewayV2HTTPResponse{StatusCode: 500}, fmt.Errorf("gchat-router: marshal payload: %w", err)
 	}
 
-	_, err = getLambdaClient().Invoke(ctx, &lambdaclient.InvokeInput{
+	_, err = lambdaClient.Invoke(ctx, &lambdaclient.InvokeInput{
 		FunctionName:   &targetFn,
 		InvocationType: types.InvocationTypeEvent,
 		Payload:        payloadBytes,

--- a/02-task-2-craftsbite/craftsbite_backend/cmd/management/main.go
+++ b/02-task-2-craftsbite/craftsbite_backend/cmd/management/main.go
@@ -3,15 +3,15 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
 	"sort"
 	"strings"
-	"sync"
 
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/sayad-ika/craftsbite/internal/cmdutil"
 	appconfig "github.com/sayad-ika/craftsbite/internal/config"
 	"github.com/sayad-ika/craftsbite/internal/dateutil"
-	"github.com/sayad-ika/craftsbite/internal/discord"
 	"github.com/sayad-ika/craftsbite/internal/dynamo"
 	"github.com/sayad-ika/craftsbite/internal/gchat"
 	"github.com/sayad-ika/craftsbite/internal/payload"
@@ -19,76 +19,53 @@ import (
 	"github.com/sayad-ika/craftsbite/internal/services"
 )
 
-var (
-	cfgOnce sync.Once
-	cfg     *appconfig.Config
-)
-
-func getConfig() *appconfig.Config {
-	cfgOnce.Do(func() {
-		cfg = appconfig.MustLoad()
-	})
-	return cfg
-}
-
-func handler(ctx context.Context, event payload.CommandEvent) error {
-	c := getConfig()
-	client := dynamo.GetClient(c)
-
+func handler(ctx context.Context, client *dynamodb.Client, cfg *appconfig.Config, dateParser *dateutil.DateParser, event payload.CommandEvent) error {
 	switch event.CommandName {
 	case "team-summary":
-		return handleTeamSummaryCommand(ctx, client, c, event)
+		return handleTeamSummaryCommand(ctx, client, cfg, dateParser, event)
 	case "override":
-		return sendMgmtReply(ctx, c, event, "This feature is coming soon.")
+		return cmdutil.SendReply(ctx, cfg, event, "This feature is coming soon.")
 	default:
-		return sendMgmtReply(ctx, c, event, fmt.Sprintf("Unknown command: /%s", event.CommandName))
+		return cmdutil.SendReply(ctx, cfg, event, fmt.Sprintf("Unknown command: /%s", event.CommandName))
 	}
 }
 
-func sendMgmtReply(ctx context.Context, c *appconfig.Config, event payload.CommandEvent, text string) error {
-	if event.Source == "gchat" {
-		card, _ := gchat.SimpleTextCard(text)
-		return gchat.CreatePrivateMessage(ctx, c.GChatServiceAccountJSON, event.GChatSpaceName, event.GChatViewerName, card)
-	}
-	return discord.SendFollowup(event.ApplicationID, event.InteractionToken, text)
-}
-
-func handleTeamSummaryCommand(ctx context.Context, client *dynamodb.Client, c *appconfig.Config, event payload.CommandEvent) error {
+func handleTeamSummaryCommand(ctx context.Context, client *dynamodb.Client, cfg *appconfig.Config, dateParser *dateutil.DateParser, event payload.CommandEvent) error {
 	if event.Role != "team_lead" && event.Role != "admin" {
-		return sendMgmtReply(ctx, c, event, "You do not have permission to use `/team-summary`.")
+		return cmdutil.SendReply(ctx, cfg, event, "You do not have permission to use `/team-summary`.")
 	}
 
-	dateStr, _ := optString(event.Options, "date")
-	date, err := dateutil.ParseDateWithDefaults(dateStr)
+	dateStr, _ := cmdutil.OptString(event.Options, "date")
+	date, err := dateParser.ParseDateWithDefaults(dateStr)
 	if err != nil {
-		return sendMgmtReply(ctx, c, event, fmt.Sprintf("Invalid date: %v\nUse: tomorrow (default), +N, or YYYY-MM-DD", err))
+		return cmdutil.SendReply(ctx, cfg, event, fmt.Sprintf("Invalid date: %v\nUse: tomorrow (default), +N, or YYYY-MM-DD", err))
 	}
 
-	teams, err := repository.FindTeamsByLeadID(ctx, client, c.DynamoDBTable, event.UserID)
+	teams, err := repository.FindTeamsByLeadID(ctx, client, cfg.DynamoDBTable, event.UserID)
 	if err != nil {
-		return sendMgmtReply(ctx, c, event, "Something went wrong fetching your team. Please try again later.")
+		return cmdutil.SendReply(ctx, cfg, event, "Something went wrong fetching your team. Please try again later.")
 	}
 	if len(teams) == 0 {
-		return sendMgmtReply(ctx, c, event, "You are not assigned as a team lead to any team.")
+		return cmdutil.SendReply(ctx, cfg, event, "You are not assigned as a team lead to any team.")
 	}
 
-	team, err := repository.GetTeamByID(ctx, client, c.DynamoDBTable, teams[0].ID)
+	team, err := repository.GetTeamByID(ctx, client, cfg.DynamoDBTable, teams[0].ID)
 	if err != nil || team == nil {
-		return sendMgmtReply(ctx, c, event, "Team not found. Please try again later.")
+		return cmdutil.SendReply(ctx, cfg, event, "Team not found. Please try again later.")
 	}
 
-	summary, err := services.GetTeamSummary(ctx, client, c.DynamoDBTable, teams[0].ID, date)
+	summary, err := services.GetTeamSummary(ctx, client, cfg.DynamoDBTable, teams[0].ID, date)
 	if err != nil {
-		return sendMgmtReply(ctx, c, event, "Something went wrong fetching the team summary. Please try again later.")
+		return cmdutil.SendReply(ctx, cfg, event, "Something went wrong fetching the team summary. Please try again later.")
 	}
 
 	if event.Source == "gchat" {
 		rows := buildTeamSummaryRows(team, summary)
 		card, _ := gchat.TeamSummaryCard(date, rows)
-		return gchat.CreatePrivateMessage(ctx, c.GChatServiceAccountJSON, event.GChatSpaceName, event.GChatViewerName, card)
+		return cmdutil.SendGChatCard(ctx, cfg, event, card)
 	}
 
-	return discord.SendFollowup(event.ApplicationID, event.InteractionToken, formatTeamSummary(team, date, summary))
+	return cmdutil.SendReply(ctx, cfg, event, formatTeamSummary(team, date, summary))
 }
 
 func buildTeamSummaryRows(team *repository.Team, summary *services.TeamSummary) []gchat.TeamRow {
@@ -105,7 +82,7 @@ func buildTeamSummaryRows(team *repository.Team, summary *services.TeamSummary) 
 
 	for _, mt := range mealTypes {
 		rows = append(rows, gchat.TeamRow{
-			Label: displayMealName(mt),
+			Label: cmdutil.DisplayMealName(mt),
 			Value: fmt.Sprintf("%d / %d", summary.MealCounts[mt], summary.MemberCount),
 		})
 	}
@@ -117,15 +94,6 @@ func buildTeamSummaryRows(team *repository.Team, summary *services.TeamSummary) 
 	})
 
 	return rows
-}
-
-func optString(opts map[string]interface{}, key string) (string, bool) {
-	v, ok := opts[key]
-	if !ok {
-		return "", false
-	}
-	s, ok := v.(string)
-	return s, ok
 }
 
 func formatTeamSummary(team *repository.Team, date string, summary *services.TeamSummary) string {
@@ -145,7 +113,7 @@ func formatTeamSummary(team *repository.Team, date string, summary *services.Tea
 	if len(mealTypes) > 0 {
 		parts := make([]string, 0, len(mealTypes))
 		for _, mt := range mealTypes {
-			parts = append(parts, fmt.Sprintf("%s %d/%d", displayMealName(mt), summary.MealCounts[mt], summary.MemberCount))
+			parts = append(parts, fmt.Sprintf("%s %d/%d", cmdutil.DisplayMealName(mt), summary.MealCounts[mt], summary.MemberCount))
 		}
 		fmt.Fprintf(&sb, "Meals:    %s\n", strings.Join(parts, "  │  "))
 	}
@@ -156,16 +124,18 @@ func formatTeamSummary(team *repository.Team, date string, summary *services.Tea
 	return sb.String()
 }
 
-func displayMealName(s string) string {
-	words := strings.Split(strings.ReplaceAll(s, "_", " "), " ")
-	for i, w := range words {
-		if len(w) > 0 {
-			words[i] = strings.ToUpper(w[:1]) + w[1:]
-		}
-	}
-	return strings.Join(words, " ")
-}
-
 func main() {
-	lambda.Start(handler)
+	cfg := appconfig.MustLoad()
+	client, err := dynamo.NewClient(cfg)
+	if err != nil {
+		log.Fatalf("management: %v", err)
+	}
+	dateParser, err := dateutil.NewDateParser(cfg.Timezone)
+	if err != nil {
+		log.Fatalf("management: %v", err)
+	}
+
+	lambda.Start(func(ctx context.Context, event payload.CommandEvent) error {
+		return handler(ctx, client, cfg, dateParser, event)
+	})
 }

--- a/02-task-2-craftsbite/craftsbite_backend/cmd/ops/main.go
+++ b/02-task-2-craftsbite/craftsbite_backend/cmd/ops/main.go
@@ -4,118 +4,84 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"strings"
-	"sync"
 
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/sayad-ika/craftsbite/internal/cmdutil"
 	appconfig "github.com/sayad-ika/craftsbite/internal/config"
 	"github.com/sayad-ika/craftsbite/internal/dateutil"
-	"github.com/sayad-ika/craftsbite/internal/discord"
 	"github.com/sayad-ika/craftsbite/internal/dynamo"
-	"github.com/sayad-ika/craftsbite/internal/gchat"
 	"github.com/sayad-ika/craftsbite/internal/headcountreport"
 	"github.com/sayad-ika/craftsbite/internal/payload"
 	"github.com/sayad-ika/craftsbite/internal/repository"
 	"github.com/sayad-ika/craftsbite/internal/services"
 )
 
-var (
-	cfgOnce sync.Once
-	cfg     *appconfig.Config
-)
-
-func getConfig() *appconfig.Config {
-	cfgOnce.Do(func() {
-		cfg = appconfig.MustLoad()
-	})
-	return cfg
-}
-
-func handler(ctx context.Context, event payload.CommandEvent) error {
-	c := getConfig()
-	client := dynamo.GetClient(c)
-
+func handler(ctx context.Context, client *dynamodb.Client, cfg *appconfig.Config, dateParser *dateutil.DateParser, event payload.CommandEvent) error {
 	switch event.CommandName {
 	case "headcount":
-		return handleHeadcountCommand(ctx, client, c, event)
+		return handleHeadcountCommand(ctx, client, cfg, dateParser, event)
 	case "schedule-day":
-		return handleScheduleDayCommand(ctx, client, c, event)
+		return handleScheduleDayCommand(ctx, client, cfg, dateParser, event)
 	case "admin":
-		return sendOpsReply(ctx, c, event, "This feature is coming soon.")
+		return cmdutil.SendReply(ctx, cfg, event, "This feature is coming soon.")
 	default:
-		return sendOpsReply(ctx, c, event, fmt.Sprintf("Unknown command: /%s", event.CommandName))
+		return cmdutil.SendReply(ctx, cfg, event, fmt.Sprintf("Unknown command: /%s", event.CommandName))
 	}
 }
 
-func sendOpsReply(ctx context.Context, c *appconfig.Config, event payload.CommandEvent, text string) error {
-	if event.Source == "gchat" {
-		card, _ := gchat.SimpleTextCard(text)
-		return gchat.CreatePrivateMessage(ctx, c.GChatServiceAccountJSON, event.GChatSpaceName, event.GChatViewerName, card)
-	}
-	return discord.SendFollowup(event.ApplicationID, event.InteractionToken, text)
-}
-
-func handleHeadcountCommand(ctx context.Context, client *dynamodb.Client, c *appconfig.Config, event payload.CommandEvent) error {
+func handleHeadcountCommand(ctx context.Context, client *dynamodb.Client, cfg *appconfig.Config, dateParser *dateutil.DateParser, event payload.CommandEvent) error {
 	if event.Role != "admin" && event.Role != "logistics" {
-		return sendOpsReply(ctx, c, event, "You do not have permission to use `/headcount`.")
+		return cmdutil.SendReply(ctx, cfg, event, "You do not have permission to use `/headcount`.")
 	}
 
-	dateStr, _ := optString(event.Options, "date")
-	date, err := dateutil.ParseDateWithDefaults(dateStr)
+	dateStr, _ := cmdutil.OptString(event.Options, "date")
+	date, err := dateParser.ParseDateWithDefaults(dateStr)
 	if err != nil {
-		return sendOpsReply(ctx, c, event, fmt.Sprintf("Invalid date: %v\nUse: tomorrow (default), +N, or YYYY-MM-DD", err))
+		return cmdutil.SendReply(ctx, cfg, event, fmt.Sprintf("Invalid date: %v\nUse: tomorrow (default), +N, or YYYY-MM-DD", err))
 	}
 
-	result, err := services.GetHeadcount(ctx, client, c.DynamoDBTable, date)
+	result, err := services.GetHeadcount(ctx, client, cfg.DynamoDBTable, date)
 	if err != nil {
-		return sendOpsReply(ctx, c, event, "Something went wrong fetching headcount. Please try again later.")
+		return cmdutil.SendReply(ctx, cfg, event, "Something went wrong fetching headcount. Please try again later.")
 	}
 
 	if event.Source == "gchat" {
 		card, _ := headcountreport.BuildGChatCard(result)
-		return gchat.CreatePrivateMessage(ctx, c.GChatServiceAccountJSON, event.GChatSpaceName, event.GChatViewerName, card)
+		return cmdutil.SendGChatCard(ctx, cfg, event, card)
 	}
 
-	return discord.SendFollowup(event.ApplicationID, event.InteractionToken, headcountreport.BuildDiscordMessage(result))
+	return cmdutil.SendReply(ctx, cfg, event, headcountreport.BuildDiscordMessage(result))
 }
 
-func optString(opts map[string]interface{}, key string) (string, bool) {
-	v, ok := opts[key]
-	if !ok {
-		return "", false
-	}
-	s, ok := v.(string)
-	return s, ok
-}
-
-func handleScheduleDayCommand(ctx context.Context, client *dynamodb.Client, c *appconfig.Config, event payload.CommandEvent) error {
+func handleScheduleDayCommand(ctx context.Context, client *dynamodb.Client, cfg *appconfig.Config, dateParser *dateutil.DateParser, event payload.CommandEvent) error {
 	if event.Role != "admin" {
-		return sendOpsReply(ctx, c, event, "You do not have permission to use `/schedule-day`.")
+		return cmdutil.SendReply(ctx, cfg, event, "You do not have permission to use `/schedule-day`.")
 	}
 
-	dateStr, _ := optString(event.Options, "date")
-
-	dates, err := dateutil.ParseDateRange(dateStr)
+	dateStr, _ := cmdutil.OptString(event.Options, "date")
+	dates, err := dateParser.ParseDateRange(dateStr)
 	if err != nil {
-		return sendOpsReply(ctx, c, event, fmt.Sprintf("Invalid date: %v\nUse: YYYY-MM-DD, YYYY-MM-DD..YYYY-MM-DD, or week", err))
+		return cmdutil.SendReply(ctx, cfg, event, fmt.Sprintf("Invalid date: %v\nUse: YYYY-MM-DD, YYYY-MM-DD..YYYY-MM-DD, or week", err))
 	}
 
-	statusStr, ok := optString(event.Options, "status")
+	statusStr, ok := cmdutil.OptString(event.Options, "status")
 	if !ok || statusStr == "" {
-		return sendOpsReply(ctx, c, event, fmt.Sprintf("Day status is required. Valid values: %v", repository.ValidDayStatuses()))
+		return cmdutil.SendReply(ctx, cfg, event, fmt.Sprintf("Day status is required. Valid values: %v", repository.ValidDayStatuses()))
 	}
 
-	mealsStr, _ := optString(event.Options, "meals")
+	mealsStr, _ := cmdutil.OptString(event.Options, "meals")
 	var meals []string
 	if mealsStr != "" {
 		meals = strings.Split(strings.ReplaceAll(mealsStr, " ", ""), ",")
 	}
 
-	reason, _ := optString(event.Options, "reason")
+	reason, _ := cmdutil.OptString(event.Options, "reason")
 
 	if len(dates) > 1 {
-		return handleBulkScheduleDayCommand(ctx, client, c, event, dates, statusStr, meals, reason)
+		return handleBulkScheduleDayCommand(ctx, client, cfg, event, dates, statusStr, meals, reason)
 	}
 
 	input := services.SetDayScheduleInput{
@@ -126,15 +92,15 @@ func handleScheduleDayCommand(ctx context.Context, client *dynamodb.Client, c *a
 		SetBy:          event.UserID,
 	}
 
-	schedule, err := services.SetDaySchedule(ctx, client, c.DynamoDBTable, input)
+	schedule, err := services.SetDaySchedule(ctx, client, cfg.DynamoDBTable, input)
 	if err != nil {
-		return sendOpsReply(ctx, c, event, formatScheduleDayError(err))
+		return cmdutil.SendReply(ctx, cfg, event, formatScheduleDayError(err))
 	}
 
-	return sendOpsReply(ctx, c, event, formatScheduleDaySuccess(schedule))
+	return cmdutil.SendReply(ctx, cfg, event, formatScheduleDaySuccess(schedule))
 }
 
-func handleBulkScheduleDayCommand(ctx context.Context, client *dynamodb.Client, c *appconfig.Config, event payload.CommandEvent, dates []string, statusStr string, meals []string, reason string) error {
+func handleBulkScheduleDayCommand(ctx context.Context, client *dynamodb.Client, cfg *appconfig.Config, event payload.CommandEvent, dates []string, statusStr string, meals []string, reason string) error {
 	input := services.SetDayScheduleInput{
 		DayStatus:      statusStr,
 		AvailableMeals: meals,
@@ -142,12 +108,12 @@ func handleBulkScheduleDayCommand(ctx context.Context, client *dynamodb.Client, 
 		SetBy:          event.UserID,
 	}
 
-	result, err := services.BulkSetDaySchedule(ctx, client, c.DynamoDBTable, dates, input)
+	result, err := services.BulkSetDaySchedule(ctx, client, cfg.DynamoDBTable, dates, input)
 	if err != nil {
-		return sendOpsReply(ctx, c, event, formatBulkScheduleDayError(err))
+		return cmdutil.SendReply(ctx, cfg, event, formatBulkScheduleDayError(err))
 	}
 
-	return sendOpsReply(ctx, c, event, formatBulkScheduleDaySuccess(result, statusStr))
+	return cmdutil.SendReply(ctx, cfg, event, formatBulkScheduleDaySuccess(result, statusStr))
 }
 
 func formatBulkScheduleDaySuccess(result *services.BulkSetDayScheduleResult, statusStr string) string {
@@ -207,5 +173,17 @@ func formatScheduleDaySuccess(schedule *repository.DaySchedule) string {
 }
 
 func main() {
-	lambda.Start(handler)
+	cfg := appconfig.MustLoad()
+	client, err := dynamo.NewClient(cfg)
+	if err != nil {
+		log.Fatalf("ops: %v", err)
+	}
+	dateParser, err := dateutil.NewDateParser(cfg.Timezone)
+	if err != nil {
+		log.Fatalf("ops: %v", err)
+	}
+
+	lambda.Start(func(ctx context.Context, event payload.CommandEvent) error {
+		return handler(ctx, client, cfg, dateParser, event)
+	})
 }

--- a/02-task-2-craftsbite/craftsbite_backend/cmd/router/main.go
+++ b/02-task-2-craftsbite/craftsbite_backend/cmd/router/main.go
@@ -4,23 +4,25 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sync"
+	"log"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	lambdaclient "github.com/aws/aws-sdk-go-v2/service/lambda"
 	"github.com/aws/aws-sdk-go-v2/service/lambda/types"
 	appconfig "github.com/sayad-ika/craftsbite/internal/config"
 	"github.com/sayad-ika/craftsbite/internal/discord"
 	"github.com/sayad-ika/craftsbite/internal/dynamo"
+	"github.com/sayad-ika/craftsbite/internal/payload"
 	"github.com/sayad-ika/craftsbite/internal/repository"
 )
 
 // Type 1 = PONG, Type 4 = immediate message, Type 5 = deferred ("thinking").
 type RouterResponse struct {
-	Type int              `json:"type"`
-	Data *ResponseData   `json:"data,omitempty"`
+	Type int           `json:"type"`
+	Data *ResponseData `json:"data,omitempty"`
 }
 
 type ResponseData struct {
@@ -58,50 +60,17 @@ type interactionBody struct {
 	} `json:"user"`
 }
 
-type CommandPayload struct {
-	UserID           string                 `json:"userID"`
-	Role             string                 `json:"role"`
-	DiscordID        string                 `json:"discordId"`
-	CommandName      string                 `json:"commandName"`
-	Options          map[string]interface{} `json:"options"`
-	InteractionToken string                 `json:"interactionToken"`
-	ApplicationID    string                 `json:"applicationId"`
-}
-
-var (
-	cfgOnce    sync.Once
-	cfg        *appconfig.Config
-	lambdaOnce sync.Once
-	lc         *lambdaclient.Client
-)
-
-func getConfig() *appconfig.Config {
-	cfgOnce.Do(func() {
-		cfg = appconfig.MustLoad()
-	})
-	return cfg
-}
-
-func newLambdaClient(c *appconfig.Config) *lambdaclient.Client {
+func newLambdaClient(c *appconfig.Config) (*lambdaclient.Client, error) {
 	awscfg, err := awsconfig.LoadDefaultConfig(context.Background(),
 		awsconfig.WithRegion(c.AWSRegion),
 	)
 	if err != nil {
-		panic(fmt.Sprintf("router: failed to load AWS config for Lambda client: %v", err))
+		return nil, fmt.Errorf("router: failed to load AWS config for Lambda client: %w", err)
 	}
-	return lambdaclient.NewFromConfig(awscfg)
+	return lambdaclient.NewFromConfig(awscfg), nil
 }
 
-func getLambdaClient() *lambdaclient.Client {
-	lambdaOnce.Do(func() {
-		lc = newLambdaClient(getConfig())
-	})
-	return lc
-}
-
-func handler(ctx context.Context, event events.APIGatewayV2HTTPRequest) (RouterResponse, error) {
-	c := getConfig()
-
+func handler(ctx context.Context, c *appconfig.Config, client *dynamodb.Client, lambdaClient *lambdaclient.Client, event events.APIGatewayV2HTTPRequest) (RouterResponse, error) {
 	timestamp := event.Headers["x-signature-timestamp"]
 	signature := event.Headers["x-signature-ed25519"]
 	if !discord.VerifySignature(c.DiscordPublicKey, timestamp, event.Body, signature) {
@@ -122,7 +91,7 @@ func handler(ctx context.Context, event events.APIGatewayV2HTTPRequest) (RouterR
 		discordID = interaction.User.ID
 	}
 
-	userID, role, err := repository.GetUserByDiscordID(ctx, dynamo.GetClient(c), c.DynamoDBTable, discordID)
+	userID, role, err := repository.GetUserByDiscordID(ctx, client, c.DynamoDBTable, discordID)
 	if err != nil {
 		return RouterResponse{}, fmt.Errorf("identity resolution failed: %w", err)
 	}
@@ -151,7 +120,7 @@ func handler(ctx context.Context, event events.APIGatewayV2HTTPRequest) (RouterR
 		optionsMap[opt.Name] = opt.Value
 	}
 
-	payload := CommandPayload{
+	cmdPayload := payload.CommandEvent{
 		UserID:           userID,
 		Role:             role,
 		DiscordID:        discordID,
@@ -160,12 +129,12 @@ func handler(ctx context.Context, event events.APIGatewayV2HTTPRequest) (RouterR
 		InteractionToken: interaction.Token,
 		ApplicationID:    interaction.ApplicationID,
 	}
-	payloadBytes, err := json.Marshal(payload)
+	payloadBytes, err := json.Marshal(cmdPayload)
 	if err != nil {
 		return RouterResponse{}, fmt.Errorf("failed to marshal command payload: %w", err)
 	}
 
-	_, err = getLambdaClient().Invoke(ctx, &lambdaclient.InvokeInput{
+	_, err = lambdaClient.Invoke(ctx, &lambdaclient.InvokeInput{
 		FunctionName:   &targetFn,
 		InvocationType: types.InvocationTypeEvent,
 		Payload:        payloadBytes,
@@ -181,5 +150,17 @@ func handler(ctx context.Context, event events.APIGatewayV2HTTPRequest) (RouterR
 }
 
 func main() {
-	lambda.Start(handler)
+	cfg := appconfig.MustLoad()
+	client, err := dynamo.NewClient(cfg)
+	if err != nil {
+		log.Fatalf("router: %v", err)
+	}
+	lambdaClient, err := newLambdaClient(cfg)
+	if err != nil {
+		log.Fatalf("router: %v", err)
+	}
+
+	lambda.Start(func(ctx context.Context, event events.APIGatewayV2HTTPRequest) (RouterResponse, error) {
+		return handler(ctx, cfg, client, lambdaClient, event)
+	})
 }

--- a/02-task-2-craftsbite/craftsbite_backend/cmd/scheduled-headcount/main.go
+++ b/02-task-2-craftsbite/craftsbite_backend/cmd/scheduled-headcount/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
 	"log/slog"
 	"sync"
 
@@ -29,43 +30,21 @@ type scheduledDeps struct {
 	availableMeals func(ctx context.Context, date string) ([]string, error)
 }
 
-func handler(ctx context.Context, event ScheduledHeadcountEvent) error {
-	cfg := appconfig.MustLoad()
-
+func handler(ctx context.Context, dateParser *dateutil.DateParser, cfg *appconfig.Config, deps scheduledDeps, event ScheduledHeadcountEvent) error {
 	if cfg.DiscordHeadcountChannelID == "" {
 		return fmt.Errorf("notifier: DISCORD_HEADCOUNT_CHANNEL_ID is required")
 	}
 	if cfg.GChatHeadcountSpace == "" {
 		return fmt.Errorf("notifier: GCHAT_HEADCOUNT_SPACE is required")
 	}
-
-	client := dynamo.GetClient(cfg)
-
-	deps := scheduledDeps{
-		headcount: func(ctx context.Context, date string) (*services.HeadcountResult, error) {
-			return services.GetHeadcount(ctx, client, cfg.DynamoDBTable, date)
-		},
-		sendDiscord: func(content string) error {
-			return discord.CreateChannelMessage(cfg.DiscordBotToken, cfg.DiscordHeadcountChannelID, content)
-		},
-		sendGChat: func(ctx context.Context, body []byte) error {
-			return gchat.CreateSpaceMessage(ctx, cfg.GChatServiceAccountJSON, cfg.GChatHeadcountSpace, body)
-		},
-		listAudience: func(ctx context.Context, roles ...string) ([]repository.User, error) {
-			return repository.ListActiveUsersByRoles(ctx, client, cfg.DynamoDBTable, roles...)
-		},
-		availableMeals: func(ctx context.Context, date string) ([]string, error) {
-			return repository.GetAvailableMeals(ctx, client, cfg.DynamoDBTable, date)
-		},
-	}
-	return runScheduledHeadcount(ctx, deps, event)
+	return runScheduledHeadcount(ctx, dateParser, deps, event)
 }
 
-func runScheduledHeadcount(ctx context.Context, deps scheduledDeps, event ScheduledHeadcountEvent) error {
+func runScheduledHeadcount(ctx context.Context, dateParser *dateutil.DateParser, deps scheduledDeps, event ScheduledHeadcountEvent) error {
 	date := event.Date
 	if date == "" {
 		var err error
-		date, err = dateutil.ParseDateWithDefaults("")
+		date, err = dateParser.ParseDateWithDefaults("")
 		if err != nil {
 			return fmt.Errorf("resolve date: %w", err)
 		}
@@ -98,7 +77,9 @@ func runScheduledHeadcount(ctx context.Context, deps scheduledDeps, event Schedu
 		return fmt.Errorf("build gchat card: %w", err)
 	}
 
-	var discordErr, gchatErr error
+	var discordErr error
+	var gchatErr error
+	var mu sync.Mutex
 	var wg sync.WaitGroup
 	wg.Add(2)
 
@@ -106,7 +87,9 @@ func runScheduledHeadcount(ctx context.Context, deps scheduledDeps, event Schedu
 		defer wg.Done()
 		if err := deps.sendDiscord(discordBody); err != nil {
 			slog.Error("discord delivery failed", "error", err)
+			mu.Lock()
 			discordErr = err
+			mu.Unlock()
 		} else {
 			slog.Info("discord delivery succeeded", "date", date)
 		}
@@ -116,7 +99,9 @@ func runScheduledHeadcount(ctx context.Context, deps scheduledDeps, event Schedu
 		defer wg.Done()
 		if err := deps.sendGChat(ctx, gchatBody); err != nil {
 			slog.Error("gchat delivery failed", "error", err)
+			mu.Lock()
 			gchatErr = err
+			mu.Unlock()
 		} else {
 			slog.Info("gchat delivery succeeded", "date", date)
 		}
@@ -131,5 +116,35 @@ func runScheduledHeadcount(ctx context.Context, deps scheduledDeps, event Schedu
 }
 
 func main() {
-	lambda.Start(handler)
+	cfg := appconfig.MustLoad()
+	client, err := dynamo.NewClient(cfg)
+	if err != nil {
+		log.Fatalf("scheduled-headcount: %v", err)
+	}
+	dateParser, err := dateutil.NewDateParser(cfg.Timezone)
+	if err != nil {
+		log.Fatalf("scheduled-headcount: %v", err)
+	}
+
+	deps := scheduledDeps{
+		headcount: func(ctx context.Context, date string) (*services.HeadcountResult, error) {
+			return services.GetHeadcount(ctx, client, cfg.DynamoDBTable, date)
+		},
+		sendDiscord: func(content string) error {
+			return discord.CreateChannelMessage(cfg.DiscordBotToken, cfg.DiscordHeadcountChannelID, content)
+		},
+		sendGChat: func(ctx context.Context, body []byte) error {
+			return gchat.CreateSpaceMessage(ctx, cfg.GChatServiceAccountJSON, cfg.GChatHeadcountSpace, body)
+		},
+		listAudience: func(ctx context.Context, roles ...string) ([]repository.User, error) {
+			return repository.ListActiveUsersByRoles(ctx, client, cfg.DynamoDBTable, roles...)
+		},
+		availableMeals: func(ctx context.Context, date string) ([]string, error) {
+			return repository.GetAvailableMeals(ctx, client, cfg.DynamoDBTable, date)
+		},
+	}
+
+	lambda.Start(func(ctx context.Context, event ScheduledHeadcountEvent) error {
+		return handler(ctx, dateParser, cfg, deps, event)
+	})
 }

--- a/02-task-2-craftsbite/craftsbite_backend/cmd/scheduled-headcount/main_test.go
+++ b/02-task-2-craftsbite/craftsbite_backend/cmd/scheduled-headcount/main_test.go
@@ -7,9 +7,19 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sayad-ika/craftsbite/internal/dateutil"
 	"github.com/sayad-ika/craftsbite/internal/repository"
 	"github.com/sayad-ika/craftsbite/internal/services"
 )
+
+func testDateParser(t *testing.T) *dateutil.DateParser {
+	t.Helper()
+	parser, err := dateutil.NewDateParser("Asia/Dhaka")
+	if err != nil {
+		t.Fatalf("NewDateParser() returned unexpected error: %v", err)
+	}
+	return parser
+}
 
 func TestRunScheduledHeadcount_NoMeals(t *testing.T) {
 	deps := scheduledDeps{
@@ -33,7 +43,7 @@ func TestRunScheduledHeadcount_NoMeals(t *testing.T) {
 		},
 	}
 
-	err := runScheduledHeadcount(context.Background(), deps, ScheduledHeadcountEvent{})
+	err := runScheduledHeadcount(context.Background(), testDateParser(t), deps, ScheduledHeadcountEvent{})
 	if err != nil {
 		t.Fatalf("expected nil for no meals, got %v", err)
 	}
@@ -60,7 +70,7 @@ func TestRunScheduledHeadcount_HeadcountError(t *testing.T) {
 		},
 	}
 
-	err := runScheduledHeadcount(context.Background(), deps, ScheduledHeadcountEvent{})
+	err := runScheduledHeadcount(context.Background(), testDateParser(t), deps, ScheduledHeadcountEvent{})
 	if err == nil {
 		t.Fatal("expected error when headcount fails")
 	}
@@ -90,7 +100,7 @@ func TestRunScheduledHeadcount_BothSucceed(t *testing.T) {
 		},
 	}
 
-	err := runScheduledHeadcount(context.Background(), deps, ScheduledHeadcountEvent{})
+	err := runScheduledHeadcount(context.Background(), testDateParser(t), deps, ScheduledHeadcountEvent{})
 	if err != nil {
 		t.Fatalf("expected nil, got %v", err)
 	}
@@ -124,7 +134,7 @@ func TestRunScheduledHeadcount_DiscordFails_GChatSucceeds(t *testing.T) {
 		},
 	}
 
-	err := runScheduledHeadcount(context.Background(), deps, ScheduledHeadcountEvent{})
+	err := runScheduledHeadcount(context.Background(), testDateParser(t), deps, ScheduledHeadcountEvent{})
 	if err == nil {
 		t.Fatal("expected error when discord fails")
 	}
@@ -155,7 +165,7 @@ func TestRunScheduledHeadcount_GChatFails_DiscordSucceeds(t *testing.T) {
 		},
 	}
 
-	err := runScheduledHeadcount(context.Background(), deps, ScheduledHeadcountEvent{})
+	err := runScheduledHeadcount(context.Background(), testDateParser(t), deps, ScheduledHeadcountEvent{})
 	if err == nil {
 		t.Fatal("expected error when gchat fails")
 	}
@@ -192,7 +202,7 @@ func TestRunScheduledHeadcount_DeliveriesRunInParallel(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- runScheduledHeadcount(context.Background(), deps, ScheduledHeadcountEvent{Date: "2026-05-01"})
+		errCh <- runScheduledHeadcount(context.Background(), testDateParser(t), deps, ScheduledHeadcountEvent{Date: "2026-05-01"})
 	}()
 
 	select {
@@ -238,7 +248,7 @@ func TestRunScheduledHeadcount_BothFail(t *testing.T) {
 		},
 	}
 
-	err := runScheduledHeadcount(context.Background(), deps, ScheduledHeadcountEvent{})
+	err := runScheduledHeadcount(context.Background(), testDateParser(t), deps, ScheduledHeadcountEvent{})
 	if err == nil {
 		t.Fatal("expected error when both deliveries fail")
 	}
@@ -262,7 +272,7 @@ func TestRunScheduledHeadcount_DateOverride(t *testing.T) {
 		},
 	}
 
-	err := runScheduledHeadcount(context.Background(), deps, ScheduledHeadcountEvent{Date: "2026-05-01"})
+	err := runScheduledHeadcount(context.Background(), testDateParser(t), deps, ScheduledHeadcountEvent{Date: "2026-05-01"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/02-task-2-craftsbite/craftsbite_backend/cmd/self/main.go
+++ b/02-task-2-craftsbite/craftsbite_backend/cmd/self/main.go
@@ -3,98 +3,63 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/sayad-ika/craftsbite/internal/cmdutil"
 	appconfig "github.com/sayad-ika/craftsbite/internal/config"
 	"github.com/sayad-ika/craftsbite/internal/dateutil"
-	"github.com/sayad-ika/craftsbite/internal/discord"
 	"github.com/sayad-ika/craftsbite/internal/dynamo"
 	"github.com/sayad-ika/craftsbite/internal/gchat"
 	"github.com/sayad-ika/craftsbite/internal/payload"
+	"github.com/sayad-ika/craftsbite/internal/repository"
 	"github.com/sayad-ika/craftsbite/internal/services"
 )
 
-var validMealOptions = map[string]bool{
-	"lunch":           true,
-	"snacks":          true,
-	"iftar":           true,
-	"event_dinner":    true,
-	"optional_dinner": true,
-	"all":             true,
-}
-
-var (
-	cfgOnce sync.Once
-	cfg     *appconfig.Config
-)
-
-func getConfig() *appconfig.Config {
-	cfgOnce.Do(func() {
-		cfg = appconfig.MustLoad()
-	})
-	return cfg
-}
-
-func handler(ctx context.Context, event payload.CommandEvent) error {
-	c := getConfig()
-	client := dynamo.GetClient(c)
-
+func handler(ctx context.Context, client *dynamodb.Client, cfg *appconfig.Config, dateParser *dateutil.DateParser, cutoff *services.CutoffChecker, event payload.CommandEvent) error {
 	switch event.CommandName {
 	case "meal":
-		replyContent := handleMeal(ctx, client, c.DynamoDBTable, event)
-		if event.Source == "gchat" {
-			card, _ := gchat.SimpleTextCard(replyContent)
-			return gchat.CreatePrivateMessage(ctx, c.GChatServiceAccountJSON, event.GChatSpaceName, event.GChatViewerName, card)
-		}
-		return discord.SendFollowup(event.ApplicationID, event.InteractionToken, replyContent)
-
+		replyContent := handleMeal(ctx, client, cfg.DynamoDBTable, dateParser, cutoff, event)
+		return cmdutil.SendReply(ctx, cfg, event, replyContent)
 	case "location":
-		return handleLocationCommand(ctx, client, c, event)
-
+		return handleLocationCommand(ctx, client, cfg, dateParser, cutoff, event)
 	case "status":
-		return handleStatusCommand(ctx, client, c, event)
-
+		return handleStatusCommand(ctx, client, cfg, dateParser, event)
 	default:
-		replyContent := fmt.Sprintf("Unknown command: /%s", event.CommandName)
-		if event.Source == "gchat" {
-			card, _ := gchat.SimpleTextCard(replyContent)
-			return gchat.CreatePrivateMessage(ctx, c.GChatServiceAccountJSON, event.GChatSpaceName, event.GChatViewerName, card)
-		}
-		return discord.SendFollowup(event.ApplicationID, event.InteractionToken, replyContent)
+		return cmdutil.SendReply(ctx, cfg, event, fmt.Sprintf("Unknown command: /%s", event.CommandName))
 	}
 }
 
-func handleStatusCommand(ctx context.Context, client *dynamodb.Client, c *appconfig.Config, event payload.CommandEvent) error {
-	dateStr, _ := optString(event.Options, "date")
-	date, err := dateutil.ParseDateWithDefaults(dateStr)
+func handleStatusCommand(ctx context.Context, client *dynamodb.Client, cfg *appconfig.Config, dateParser *dateutil.DateParser, event payload.CommandEvent) error {
+	dateStr, _ := cmdutil.OptString(event.Options, "date")
+	date, err := dateParser.ParseDateWithDefaults(dateStr)
 	if err != nil {
-		return sendSelfReply(ctx, c, event, fmt.Sprintf("Invalid date: %v\nUse: tomorrow (default), today, +N, or YYYY-MM-DD", err))
+		return cmdutil.SendReply(ctx, cfg, event, fmt.Sprintf("Invalid date: %v\nUse: tomorrow (default), today, +N, or YYYY-MM-DD", err))
 	}
 
-	mealStatuses, err := services.GetUserMealStatus(ctx, client, c.DynamoDBTable, event.UserID, date)
+	mealStatuses, err := services.GetUserMealStatus(ctx, client, cfg.DynamoDBTable, event.UserID, date)
 	if err != nil {
-		return sendSelfReply(ctx, c, event, "Unable to fetch meal status. Please try again later.")
+		return cmdutil.SendReply(ctx, cfg, event, "Unable to fetch meal status. Please try again later.")
 	}
 
-	location, err := services.GetLocation(ctx, client, c.DynamoDBTable, event.UserID, date)
+	location, err := services.GetLocation(ctx, client, cfg.DynamoDBTable, event.UserID, date)
 	if err != nil {
-		return sendSelfReply(ctx, c, event, "Unable to fetch location status. Please try again later.")
+		return cmdutil.SendReply(ctx, cfg, event, "Unable to fetch location status. Please try again later.")
 	}
 
-	return sendSelfReply(ctx, c, event, formatStatusView(date, location.Location, mealStatuses))
+	return cmdutil.SendReply(ctx, cfg, event, formatStatusView(date, location.Location, mealStatuses))
 }
 
-func handleBulkLocationUpdate(ctx context.Context, client *dynamodb.Client, c *appconfig.Config, event payload.CommandEvent, dates []string, location string) error {
+func handleBulkLocationUpdate(ctx context.Context, client *dynamodb.Client, cfg *appconfig.Config, cutoff *services.CutoffChecker, event payload.CommandEvent, dates []string, location string) error {
 	var successDates []string
 	var failedDates []string
 	var errors []string
 
 	for _, date := range dates {
-		_, err := services.SetLocation(ctx, client, c.DynamoDBTable, event.UserID, date, location)
+		_, err := services.SetLocation(ctx, client, cfg.DynamoDBTable, event.UserID, date, location, cutoff)
 		if err != nil {
 			failedDates = append(failedDates, date)
 			errors = append(errors, fmt.Sprintf("%s: %s", date, locationErrorReply(err, date)))
@@ -103,7 +68,6 @@ func handleBulkLocationUpdate(ctx context.Context, client *dynamodb.Client, c *a
 		}
 	}
 
-	// Format response
 	var sb strings.Builder
 	if len(successDates) > 0 {
 		locLabel := "Office"
@@ -127,52 +91,40 @@ func handleBulkLocationUpdate(ctx context.Context, client *dynamodb.Client, c *a
 		}
 	}
 
-	return sendSelfReply(ctx, c, event, sb.String())
+	return cmdutil.SendReply(ctx, cfg, event, sb.String())
 }
 
-func handleLocationCommand(ctx context.Context, client *dynamodb.Client, c *appconfig.Config, event payload.CommandEvent) error {
-	dateStr, _ := optString(event.Options, "date")
-
-	// Parse date range (supports single date, range, or "week")
-	dates, err := dateutil.ParseDateRange(dateStr)
+func handleLocationCommand(ctx context.Context, client *dynamodb.Client, cfg *appconfig.Config, dateParser *dateutil.DateParser, cutoff *services.CutoffChecker, event payload.CommandEvent) error {
+	dateStr, _ := cmdutil.OptString(event.Options, "date")
+	dates, err := dateParser.ParseDateRange(dateStr)
 	if err != nil {
-		return sendSelfReply(ctx, c, event, fmt.Sprintf("Invalid date: %v\nUse: tomorrow (default), today, +N, YYYY-MM-DD, YYYY-MM-DD..YYYY-MM-DD, or week", err))
+		return cmdutil.SendReply(ctx, cfg, event, fmt.Sprintf("Invalid date: %v\nUse: tomorrow (default), today, +N, YYYY-MM-DD, YYYY-MM-DD..YYYY-MM-DD, or week", err))
 	}
 
-	loc, ok := optString(event.Options, "location")
+	loc, ok := cmdutil.OptString(event.Options, "location")
 	if !ok || (loc != "office" && loc != "wfh") {
-		return sendSelfReply(ctx, c, event, "Please specify location as `office` or `wfh`.")
+		return cmdutil.SendReply(ctx, cfg, event, "Please specify location as `office` or `wfh`.")
 	}
 
-	// Handle bulk operations for multiple dates
 	if len(dates) > 1 {
-		return handleBulkLocationUpdate(ctx, client, c, event, dates, loc)
+		return handleBulkLocationUpdate(ctx, client, cfg, cutoff, event, dates, loc)
 	}
 
-	// Single date operation
 	date := dates[0]
-	wl, err := services.SetLocation(ctx, client, c.DynamoDBTable, event.UserID, date, loc)
+	wl, err := services.SetLocation(ctx, client, cfg.DynamoDBTable, event.UserID, date, loc, cutoff)
 	if err != nil {
-		return sendSelfReply(ctx, c, event, locationErrorReply(err, date))
+		return cmdutil.SendReply(ctx, cfg, event, locationErrorReply(err, date))
 	}
 
-	mealStatuses, _ := services.GetUserMealStatus(ctx, client, c.DynamoDBTable, event.UserID, date)
+	mealStatuses, _ := services.GetUserMealStatus(ctx, client, cfg.DynamoDBTable, event.UserID, date)
 
 	if event.Source == "gchat" {
 		mealText := formatMealStatusLine(mealStatuses)
 		card, _ := gchat.LocationCard(wl.Location, date, mealText)
-		return gchat.CreatePrivateMessage(ctx, c.GChatServiceAccountJSON, event.GChatSpaceName, event.GChatViewerName, card)
+		return cmdutil.SendGChatCard(ctx, cfg, event, card)
 	}
 
-	return discord.SendFollowup(event.ApplicationID, event.InteractionToken, formatLocationStatus(date, wl.Location, mealStatuses))
-}
-
-func sendSelfReply(ctx context.Context, c *appconfig.Config, event payload.CommandEvent, text string) error {
-	if event.Source == "gchat" {
-		card, _ := gchat.SimpleTextCard(text)
-		return gchat.CreatePrivateMessage(ctx, c.GChatServiceAccountJSON, event.GChatSpaceName, event.GChatViewerName, card)
-	}
-	return discord.SendFollowup(event.ApplicationID, event.InteractionToken, text)
+	return cmdutil.SendReply(ctx, cfg, event, formatLocationStatus(date, wl.Location, mealStatuses))
 }
 
 func formatMealStatusLine(statuses []services.ResolvedStatus) string {
@@ -187,18 +139,18 @@ func formatMealStatusLine(statuses []services.ResolvedStatus) string {
 		} else if s.Status == "unavailable" {
 			icon = "—"
 		}
-		parts = append(parts, fmt.Sprintf("%s %s", displayMealName(s.MealType), icon))
+		parts = append(parts, fmt.Sprintf("%s %s", cmdutil.DisplayMealName(s.MealType), icon))
 	}
 	return strings.Join(parts, "  ")
 }
 
-func handleBulkMealUpdate(ctx context.Context, client *dynamodb.Client, table, userID string, dates []string, mealType string, isParticipating bool) string {
+func handleBulkMealUpdate(ctx context.Context, client *dynamodb.Client, table, userID string, dates []string, mealType string, isParticipating bool, cutoff *services.CutoffChecker) string {
 	var successDates []string
 	var failedDates []string
 	var errors []string
 
 	for _, date := range dates {
-		_, err := services.UpdateParticipation(ctx, client, table, userID, date, mealType, isParticipating)
+		_, err := services.UpdateParticipation(ctx, client, table, userID, date, mealType, isParticipating, cutoff)
 		if err != nil {
 			failedDates = append(failedDates, date)
 			errors = append(errors, fmt.Sprintf("%s: %s", date, mealErrorReply(err, date)))
@@ -207,14 +159,13 @@ func handleBulkMealUpdate(ctx context.Context, client *dynamodb.Client, table, u
 		}
 	}
 
-	// Format response
 	var sb strings.Builder
 	if len(successDates) > 0 {
 		action := "opted out"
 		if isParticipating {
 			action = "opted in"
 		}
-		mealLabel := displayMealName(mealType)
+		mealLabel := cmdutil.DisplayMealName(mealType)
 
 		fmt.Fprintf(&sb, "✓ Successfully %s %s for %d date(s):\n", action, mealLabel, len(successDates))
 		for _, date := range successDates {
@@ -235,44 +186,39 @@ func handleBulkMealUpdate(ctx context.Context, client *dynamodb.Client, table, u
 	return sb.String()
 }
 
-func handleMeal(ctx context.Context, client *dynamodb.Client, table string, event payload.CommandEvent) string {
-	dateStr, _ := optString(event.Options, "date")
-
-	// Parse date range (supports single date, range, or "week")
-	dates, err := dateutil.ParseDateRange(dateStr)
+func handleMeal(ctx context.Context, client *dynamodb.Client, table string, dateParser *dateutil.DateParser, cutoff *services.CutoffChecker, event payload.CommandEvent) string {
+	dateStr, _ := cmdutil.OptString(event.Options, "date")
+	dates, err := dateParser.ParseDateRange(dateStr)
 	if err != nil {
 		return fmt.Sprintf("Invalid date: %v\nUse: tomorrow (default), +N, YYYY-MM-DD, YYYY-MM-DD..YYYY-MM-DD, or week", err)
 	}
 
-	statusStr, ok := optString(event.Options, "status")
+	statusStr, ok := cmdutil.OptString(event.Options, "status")
 	if !ok || (statusStr != "in" && statusStr != "out") {
 		return "Please specify status as `in` or `out`."
 	}
 	isParticipating := statusStr == "in"
 
-	mealType, _ := optString(event.Options, "meal")
+	mealType, _ := cmdutil.OptString(event.Options, "meal")
 	if mealType == "" {
 		mealType = "all"
 	}
-	if !validMealOptions[mealType] {
-		return fmt.Sprintf("`%s` is not a valid meal type. Choose from: lunch, snacks, event_dinner, optional_dinner, all.", mealType)
+	if !repository.IsValidMealOrAll(mealType) {
+		return fmt.Sprintf("`%s` is not a valid meal type. Choose from: lunch, snacks, iftar, event_dinner, optional_dinner, all.", mealType)
 	}
 
-	// Handle bulk operations for multiple dates
 	if len(dates) > 1 {
-		return handleBulkMealUpdate(ctx, client, table, event.UserID, dates, mealType, isParticipating)
+		return handleBulkMealUpdate(ctx, client, table, event.UserID, dates, mealType, isParticipating, cutoff)
 	}
 
-	// Single date operation
 	date := dates[0]
-	statuses, err := services.UpdateParticipation(ctx, client, table, event.UserID, date, mealType, isParticipating)
+	statuses, err := services.UpdateParticipation(ctx, client, table, event.UserID, date, mealType, isParticipating, cutoff)
 	if err != nil {
 		return mealErrorReply(err, date)
 	}
 
 	var changedMeals []string
 	if mealType == "all" {
-		// All available meals were changed
 		for _, s := range statuses {
 			if s.Status != "unavailable" {
 				changedMeals = append(changedMeals, s.MealType)
@@ -283,15 +229,6 @@ func handleMeal(ctx context.Context, client *dynamodb.Client, table string, even
 	}
 
 	return formatMealStatusWithChanges(date, statuses, changedMeals)
-}
-
-func optString(opts map[string]interface{}, key string) (string, bool) {
-	v, ok := opts[key]
-	if !ok {
-		return "", false
-	}
-	s, ok := v.(string)
-	return s, ok
 }
 
 func mealErrorReply(err error, date string) string {
@@ -335,7 +272,6 @@ func formatLocationStatus(date, location string, mealStatuses []services.Resolve
 	}
 
 	var sb strings.Builder
-	// Highlight the location change with arrow prefix
 	fmt.Fprintf(&sb, "Updated! Status for %s:\n → %s %s", date, locIcon, locLabel)
 
 	for _, s := range mealStatuses {
@@ -345,7 +281,7 @@ func formatLocationStatus(date, location string, mealStatuses []services.Resolve
 		} else if s.Status == "unavailable" {
 			icon = "—"
 		}
-		fmt.Fprintf(&sb, "  %s %s", displayMealName(s.MealType), icon)
+		fmt.Fprintf(&sb, "  %s %s", cmdutil.DisplayMealName(s.MealType), icon)
 	}
 	return sb.String()
 }
@@ -356,25 +292,6 @@ func prevDay(targetDate string) string {
 		return targetDate + " (previous day)"
 	}
 	return t.AddDate(0, 0, -1).Format("2006-01-02")
-}
-
-func formatMealStatus(date string, statuses []services.ResolvedStatus) string {
-	if len(statuses) == 0 {
-		return fmt.Sprintf("No meals are available on %s.", date)
-	}
-
-	var sb strings.Builder
-	fmt.Fprintf(&sb, "Updated! Meal status for %s:", date)
-	for _, s := range statuses {
-		icon := "✗"
-		if s.Status == "opted_in" {
-			icon = "✓"
-		} else if s.Status == "unavailable" {
-			icon = "—"
-		}
-		fmt.Fprintf(&sb, "  %s %s", displayMealName(s.MealType), icon)
-	}
-	return sb.String()
 }
 
 func formatMealStatusWithChanges(date string, statuses []services.ResolvedStatus, changedMeals []string) string {
@@ -392,13 +309,12 @@ func formatMealStatusWithChanges(date string, statuses []services.ResolvedStatus
 			icon = "—"
 		}
 
-		// Highlight changed meals with arrow prefix
 		prefix := "  "
 		if containsString(changedMeals, s.MealType) {
 			prefix = " →"
 		}
 
-		fmt.Fprintf(&sb, "%s %s %s", prefix, displayMealName(s.MealType), icon)
+		fmt.Fprintf(&sb, "%s %s %s", prefix, cmdutil.DisplayMealName(s.MealType), icon)
 	}
 	return sb.String()
 }
@@ -412,21 +328,10 @@ func containsString(slice []string, item string) bool {
 	return false
 }
 
-func displayMealName(s string) string {
-	words := strings.Split(strings.ReplaceAll(s, "_", " "), " ")
-	for i, w := range words {
-		if len(w) > 0 {
-			words[i] = strings.ToUpper(w[:1]) + w[1:]
-		}
-	}
-	return strings.Join(words, " ")
-}
-
 func formatStatusView(date, location string, mealStatuses []services.ResolvedStatus) string {
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "Status for %s:\n", date)
 
-	// Location status
 	locIcon := "🏢"
 	locLabel := "Office"
 	if location == "wfh" {
@@ -438,7 +343,6 @@ func formatStatusView(date, location string, mealStatuses []services.ResolvedSta
 	}
 	fmt.Fprintf(&sb, "  %s %s", locIcon, locLabel)
 
-	// Meal status
 	if len(mealStatuses) == 0 {
 		fmt.Fprintf(&sb, "\n  No meals configured")
 	} else {
@@ -449,7 +353,7 @@ func formatStatusView(date, location string, mealStatuses []services.ResolvedSta
 			} else if s.Status == "unavailable" {
 				icon = "—"
 			}
-			fmt.Fprintf(&sb, "  %s %s", displayMealName(s.MealType), icon)
+			fmt.Fprintf(&sb, "  %s %s", cmdutil.DisplayMealName(s.MealType), icon)
 		}
 	}
 
@@ -457,5 +361,21 @@ func formatStatusView(date, location string, mealStatuses []services.ResolvedSta
 }
 
 func main() {
-	lambda.Start(handler)
+	cfg := appconfig.MustLoad()
+	client, err := dynamo.NewClient(cfg)
+	if err != nil {
+		log.Fatalf("self: %v", err)
+	}
+	dateParser, err := dateutil.NewDateParser(cfg.Timezone)
+	if err != nil {
+		log.Fatalf("self: %v", err)
+	}
+	cutoff, err := services.NewCutoffChecker(services.CutoffConfig{CutoffTime: cfg.CutoffTime, Timezone: cfg.Timezone})
+	if err != nil {
+		log.Fatalf("self: %v", err)
+	}
+
+	lambda.Start(func(ctx context.Context, event payload.CommandEvent) error {
+		return handler(ctx, client, cfg, dateParser, cutoff, event)
+	})
 }

--- a/02-task-2-craftsbite/craftsbite_backend/internal/cmdutil/cmdutil.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/cmdutil/cmdutil.go
@@ -1,0 +1,46 @@
+package cmdutil
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/sayad-ika/craftsbite/internal/config"
+	"github.com/sayad-ika/craftsbite/internal/discord"
+	"github.com/sayad-ika/craftsbite/internal/gchat"
+	"github.com/sayad-ika/craftsbite/internal/payload"
+)
+
+func OptString(opts map[string]interface{}, key string) (string, bool) {
+	v, ok := opts[key]
+	if !ok {
+		return "", false
+	}
+	s, ok := v.(string)
+	return s, ok
+}
+
+func DisplayMealName(s string) string {
+	words := strings.Split(strings.ReplaceAll(s, "_", " "), " ")
+	for i, w := range words {
+		if len(w) > 0 {
+			words[i] = strings.ToUpper(w[:1]) + w[1:]
+		}
+	}
+	return strings.Join(words, " ")
+}
+
+func SendReply(ctx context.Context, cfg *config.Config, event payload.CommandEvent, text string) error {
+	if event.Source == "gchat" {
+		card, err := gchat.SimpleTextCard(text)
+		if err != nil {
+			return fmt.Errorf("cmdutil: build gchat text card: %w", err)
+		}
+		return gchat.CreatePrivateMessage(ctx, cfg.GChatServiceAccountJSON, event.GChatSpaceName, event.GChatViewerName, card)
+	}
+	return discord.SendFollowup(event.ApplicationID, event.InteractionToken, text)
+}
+
+func SendGChatCard(ctx context.Context, cfg *config.Config, event payload.CommandEvent, card []byte) error {
+	return gchat.CreatePrivateMessage(ctx, cfg.GChatServiceAccountJSON, event.GChatSpaceName, event.GChatViewerName, card)
+}

--- a/02-task-2-craftsbite/craftsbite_backend/internal/config/config.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/config/config.go
@@ -21,6 +21,8 @@ type Config struct {
 	DynamoDBEndpoint string
 
 	DynamoDBTable string
+	Timezone      string
+	CutoffTime    string
 
 	LambdaSelfFunctionName       string
 	LambdaManagementFunctionName string
@@ -57,14 +59,16 @@ func Load() (*Config, error) {
 		AWSRegion:                    os.Getenv("AWS_REGION"),
 		DynamoDBEndpoint:             os.Getenv("DYNAMODB_ENDPOINT"),
 		DynamoDBTable:                os.Getenv("DYNAMODB_TABLE"),
+		Timezone:                     os.Getenv("TIMEZONE"),
+		CutoffTime:                   os.Getenv("CUTOFF_TIME"),
 		LambdaSelfFunctionName:       os.Getenv("LAMBDA_SELF_FUNCTION_NAME"),
 		LambdaManagementFunctionName: os.Getenv("LAMBDA_MANAGEMENT_FUNCTION_NAME"),
 		LambdaOpsFunctionName:        os.Getenv("LAMBDA_OPS_FUNCTION_NAME"),
 		GChatServiceAccountJSON:      os.Getenv("GCHAT_SERVICE_ACCOUNT_JSON"),
 		DiscordHeadcountChannelID:    os.Getenv("DISCORD_HEADCOUNT_CHANNEL_ID"),
 		GChatHeadcountSpace:          os.Getenv("GCHAT_HEADCOUNT_SPACE"),
-		DiscordBotToken:  params[paramPrefix+"DISCORD_BOT_TOKEN"],
-		DiscordPublicKey: params[paramPrefix+"DISCORD_PUBLIC_KEY"],
+		DiscordBotToken:              params[paramPrefix+"DISCORD_BOT_TOKEN"],
+		DiscordPublicKey:             params[paramPrefix+"DISCORD_PUBLIC_KEY"],
 	}
 
 	if cfg.AWSRegion == "" {
@@ -72,6 +76,12 @@ func Load() (*Config, error) {
 	}
 	if cfg.DynamoDBTable == "" {
 		cfg.DynamoDBTable = "craftsbite"
+	}
+	if cfg.Timezone == "" {
+		cfg.Timezone = "Asia/Dhaka"
+	}
+	if cfg.CutoffTime == "" {
+		cfg.CutoffTime = "21:00"
 	}
 
 	var missing []string

--- a/02-task-2-craftsbite/craftsbite_backend/internal/dateutil/dateutil.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/dateutil/dateutil.go
@@ -2,7 +2,6 @@ package dateutil
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -13,15 +12,34 @@ const (
 	dateFormat      = "2006-01-02"
 )
 
+type DateParser struct {
+	loc *time.Location
+}
+
+func NewDateParser(timezone string) (*DateParser, error) {
+	tz := timezone
+	if tz == "" {
+		tz = defaultTimezone
+	}
+	loc, err := time.LoadLocation(tz)
+	if err != nil {
+		return nil, fmt.Errorf("invalid TIMEZONE %q: %w", tz, err)
+	}
+	return &DateParser{loc: loc}, nil
+}
+
 // ParseDateWithDefaults parses a date string with support for shortcuts and defaults.
 // If dateStr is empty, returns tomorrow's date.
-func ParseDateWithDefaults(dateStr string) (string, error) {
-	loc, err := loadLocation()
-	if err != nil {
-		return "", err
+func (p *DateParser) ParseDateWithDefaults(dateStr string) (string, error) {
+	return p.parseDateWithDefaultsAt(dateStr, time.Now())
+}
+
+func (p *DateParser) parseDateWithDefaultsAt(dateStr string, now time.Time) (string, error) {
+	if p == nil || p.loc == nil {
+		return "", fmt.Errorf("date parser is not initialized")
 	}
 
-	now := time.Now().In(loc)
+	now = now.In(p.loc)
 
 	// Empty string defaults to tomorrow
 	if dateStr == "" {
@@ -58,31 +76,25 @@ func ParseDateWithDefaults(dateStr string) (string, error) {
 }
 
 // TodayInTimezone returns today's date in the configured timezone
-func TodayInTimezone() string {
-	loc, err := loadLocation()
-	if err != nil {
-		loc = time.UTC
-	}
-	return time.Now().In(loc).Format(dateFormat)
+func (p *DateParser) TodayInTimezone() string {
+	return p.todayInTimezoneAt(time.Now())
 }
 
 // TomorrowInTimezone returns tomorrow's date in the configured timezone
-func TomorrowInTimezone() string {
-	loc, err := loadLocation()
-	if err != nil {
-		loc = time.UTC
-	}
-	return time.Now().In(loc).AddDate(0, 0, 1).Format(dateFormat)
+func (p *DateParser) TomorrowInTimezone() string {
+	return p.tomorrowInTimezoneAt(time.Now())
 }
 
-func loadLocation() (*time.Location, error) {
-	tz := os.Getenv("TIMEZONE")
-	if tz == "" {
-		tz = defaultTimezone
+func (p *DateParser) todayInTimezoneAt(now time.Time) string {
+	if p == nil || p.loc == nil {
+		return now.UTC().Format(dateFormat)
 	}
-	loc, err := time.LoadLocation(tz)
-	if err != nil {
-		return nil, fmt.Errorf("invalid TIMEZONE %q: %w", tz, err)
+	return now.In(p.loc).Format(dateFormat)
+}
+
+func (p *DateParser) tomorrowInTimezoneAt(now time.Time) string {
+	if p == nil || p.loc == nil {
+		return now.UTC().AddDate(0, 0, 1).Format(dateFormat)
 	}
-	return loc, nil
+	return now.In(p.loc).AddDate(0, 0, 1).Format(dateFormat)
 }

--- a/02-task-2-craftsbite/craftsbite_backend/internal/dateutil/dateutil_test.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/dateutil/dateutil_test.go
@@ -6,8 +6,7 @@ import (
 )
 
 func TestParseDateWithDefaults(t *testing.T) {
-	t.Setenv("TIMEZONE", "Asia/Dhaka")
-
+	parser := mustDateParser(t)
 	loc, _ := time.LoadLocation("Asia/Dhaka")
 	now := time.Date(2026, 3, 19, 10, 0, 0, 0, loc)
 	today := now.Format("2006-01-02")
@@ -73,44 +72,59 @@ func TestParseDateWithDefaults(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ParseDateWithDefaults(tt.input)
+			got, err := parser.parseDateWithDefaultsAt(tt.input, now)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("ParseDateWithDefaults() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("parseDateWithDefaultsAt() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !tt.wantErr && got != tt.want {
-				t.Errorf("ParseDateWithDefaults() = %v, want %v", got, tt.want)
+				t.Errorf("parseDateWithDefaultsAt() = %v, want %v", got, tt.want)
 			}
 		})
 	}
 }
 
 func TestTodayInTimezone(t *testing.T) {
-	t.Setenv("TIMEZONE", "Asia/Dhaka")
-
-	result := TodayInTimezone()
+	parser := mustDateParser(t)
+	loc, _ := time.LoadLocation("Asia/Dhaka")
+	result := parser.todayInTimezoneAt(time.Date(2026, 3, 19, 10, 0, 0, 0, loc))
 	if len(result) != 10 {
-		t.Errorf("TodayInTimezone() returned invalid format: %s", result)
+		t.Errorf("todayInTimezoneAt() returned invalid format: %s", result)
 	}
 
 	// Verify it's a valid date
 	_, err := time.Parse("2006-01-02", result)
 	if err != nil {
-		t.Errorf("TodayInTimezone() returned invalid date: %s", result)
+		t.Errorf("todayInTimezoneAt() returned invalid date: %s", result)
+	}
+	if result != "2026-03-19" {
+		t.Errorf("todayInTimezoneAt() = %s, want 2026-03-19", result)
 	}
 }
 
 func TestTomorrowInTimezone(t *testing.T) {
-	t.Setenv("TIMEZONE", "Asia/Dhaka")
-
-	result := TomorrowInTimezone()
+	parser := mustDateParser(t)
+	loc, _ := time.LoadLocation("Asia/Dhaka")
+	result := parser.tomorrowInTimezoneAt(time.Date(2026, 3, 19, 10, 0, 0, 0, loc))
 	if len(result) != 10 {
-		t.Errorf("TomorrowInTimezone() returned invalid format: %s", result)
+		t.Errorf("tomorrowInTimezoneAt() returned invalid format: %s", result)
 	}
 
 	// Verify it's a valid date
 	_, err := time.Parse("2006-01-02", result)
 	if err != nil {
-		t.Errorf("TomorrowInTimezone() returned invalid date: %s", result)
+		t.Errorf("tomorrowInTimezoneAt() returned invalid date: %s", result)
 	}
+	if result != "2026-03-20" {
+		t.Errorf("tomorrowInTimezoneAt() = %s, want 2026-03-20", result)
+	}
+}
+
+func mustDateParser(t *testing.T) *DateParser {
+	t.Helper()
+	parser, err := NewDateParser("Asia/Dhaka")
+	if err != nil {
+		t.Fatalf("NewDateParser() returned unexpected error: %v", err)
+	}
+	return parser
 }

--- a/02-task-2-craftsbite/craftsbite_backend/internal/dateutil/range.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/dateutil/range.go
@@ -11,26 +11,30 @@ import (
 // - Single date: "2026-03-20" or shortcuts (tomorrow, +N)
 // - Date range: "2026-03-20..2026-03-22"
 // - Week keyword: "week" (next 5 business days from tomorrow)
-func ParseDateRange(dateParam string) ([]string, error) {
+func (p *DateParser) ParseDateRange(dateParam string) ([]string, error) {
+	return p.parseDateRangeAt(dateParam, time.Now())
+}
+
+func (p *DateParser) parseDateRangeAt(dateParam string, now time.Time) ([]string, error) {
 	// Handle date range syntax: "2026-03-20..2026-03-22"
 	if strings.Contains(dateParam, "..") {
-		return parseDateRangeSyntax(dateParam)
+		return p.parseDateRangeSyntaxAt(dateParam, now)
 	}
 
 	// Handle "week" keyword
 	if strings.ToLower(dateParam) == "week" {
-		return getNextBusinessWeek()
+		return p.getNextBusinessWeekAt(now)
 	}
 
 	// Single date - use existing parser
-	date, err := ParseDateWithDefaults(dateParam)
+	date, err := p.parseDateWithDefaultsAt(dateParam, now)
 	if err != nil {
 		return nil, err
 	}
 	return []string{date}, nil
 }
 
-func parseDateRangeSyntax(rangeStr string) ([]string, error) {
+func (p *DateParser) parseDateRangeSyntaxAt(rangeStr string, now time.Time) ([]string, error) {
 	parts := strings.Split(rangeStr, "..")
 	if len(parts) != 2 {
 		return nil, fmt.Errorf("invalid date range format: %s (use YYYY-MM-DD..YYYY-MM-DD)", rangeStr)
@@ -40,13 +44,13 @@ func parseDateRangeSyntax(rangeStr string) ([]string, error) {
 	endStr := strings.TrimSpace(parts[1])
 
 	// Parse start date (supports shortcuts)
-	startDate, err := ParseDateWithDefaults(startStr)
+	startDate, err := p.parseDateWithDefaultsAt(startStr, now)
 	if err != nil {
 		return nil, fmt.Errorf("invalid start date: %w", err)
 	}
 
 	// Parse end date (supports shortcuts)
-	endDate, err := ParseDateWithDefaults(endStr)
+	endDate, err := p.parseDateWithDefaultsAt(endStr, now)
 	if err != nil {
 		return nil, fmt.Errorf("invalid end date: %w", err)
 	}
@@ -81,13 +85,12 @@ func parseDateRangeSyntax(rangeStr string) ([]string, error) {
 	return dates, nil
 }
 
-func getNextBusinessWeek() ([]string, error) {
-	loc, err := loadLocation()
-	if err != nil {
-		return nil, err
+func (p *DateParser) getNextBusinessWeekAt(now time.Time) ([]string, error) {
+	if p == nil || p.loc == nil {
+		return nil, fmt.Errorf("date parser is not initialized")
 	}
 
-	now := time.Now().In(loc)
+	now = now.In(p.loc)
 	tomorrow := now.AddDate(0, 0, 1)
 
 	var dates []string

--- a/02-task-2-craftsbite/craftsbite_backend/internal/dateutil/range_test.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/dateutil/range_test.go
@@ -6,7 +6,8 @@ import (
 )
 
 func TestParseDateRange_SingleDate(t *testing.T) {
-	dates, err := ParseDateRange("2026-03-20")
+	parser := mustDateParser(t)
+	dates, err := parser.ParseDateRange("2026-03-20")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -19,23 +20,25 @@ func TestParseDateRange_SingleDate(t *testing.T) {
 }
 
 func TestParseDateRange_EmptyString(t *testing.T) {
-	dates, err := ParseDateRange("")
+	parser := mustDateParser(t)
+	loc, _ := time.LoadLocation("Asia/Dhaka")
+	now := time.Date(2026, 3, 19, 10, 0, 0, 0, loc)
+	dates, err := parser.parseDateRangeAt("", now)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(dates) != 1 {
 		t.Errorf("expected 1 date, got %d", len(dates))
 	}
-	// Should default to tomorrow
-	loc, _ := time.LoadLocation("Asia/Dhaka")
-	tomorrow := time.Now().In(loc).AddDate(0, 0, 1).Format("2006-01-02")
+	tomorrow := now.In(loc).AddDate(0, 0, 1).Format("2006-01-02")
 	if dates[0] != tomorrow {
 		t.Errorf("date = %q, want %q (tomorrow)", dates[0], tomorrow)
 	}
 }
 
 func TestParseDateRange_Range(t *testing.T) {
-	dates, err := ParseDateRange("2026-03-20..2026-03-22")
+	parser := mustDateParser(t)
+	dates, err := parser.ParseDateRange("2026-03-20..2026-03-22")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -51,41 +54,60 @@ func TestParseDateRange_Range(t *testing.T) {
 }
 
 func TestParseDateRange_RangeWithShortcuts(t *testing.T) {
-	dates, err := ParseDateRange("today..+2")
+	parser := mustDateParser(t)
+	loc, _ := time.LoadLocation("Asia/Dhaka")
+	dates, err := parser.parseDateRangeAt("today..+2", time.Date(2026, 3, 19, 10, 0, 0, 0, loc))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(dates) != 3 {
 		t.Errorf("expected 3 dates, got %d", len(dates))
 	}
+	expected := []string{"2026-03-19", "2026-03-20", "2026-03-21"}
+	for i, want := range expected {
+		if dates[i] != want {
+			t.Errorf("dates[%d] = %q, want %q", i, dates[i], want)
+		}
+	}
 }
 
 func TestParseDateRange_Week(t *testing.T) {
-	dates, err := ParseDateRange("week")
+	parser := mustDateParser(t)
+	loc, _ := time.LoadLocation("Asia/Dhaka")
+	dates, err := parser.parseDateRangeAt("week", time.Date(2026, 3, 20, 10, 0, 0, 0, loc))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(dates) != 5 {
 		t.Errorf("expected 5 business days, got %d", len(dates))
 	}
+	expected := []string{"2026-03-23", "2026-03-24", "2026-03-25", "2026-03-26", "2026-03-27"}
+	for i, want := range expected {
+		if dates[i] != want {
+			t.Errorf("dates[%d] = %q, want %q", i, dates[i], want)
+		}
+	}
 }
 
 func TestParseDateRange_TooLarge(t *testing.T) {
-	_, err := ParseDateRange("2026-03-01..2026-03-20")
+	parser := mustDateParser(t)
+	_, err := parser.ParseDateRange("2026-03-01..2026-03-20")
 	if err == nil {
 		t.Fatal("expected error for range > 14 days, got nil")
 	}
 }
 
 func TestParseDateRange_InvalidRange(t *testing.T) {
-	_, err := ParseDateRange("2026-03-22..2026-03-20")
+	parser := mustDateParser(t)
+	_, err := parser.ParseDateRange("2026-03-22..2026-03-20")
 	if err == nil {
 		t.Fatal("expected error for end before start, got nil")
 	}
 }
 
 func TestParseDateRange_InvalidFormat(t *testing.T) {
-	_, err := ParseDateRange("2026-03-20..2026-03-22..2026-03-24")
+	parser := mustDateParser(t)
+	_, err := parser.ParseDateRange("2026-03-20..2026-03-22..2026-03-24")
 	if err == nil {
 		t.Fatal("expected error for invalid range format, got nil")
 	}

--- a/02-task-2-craftsbite/craftsbite_backend/internal/dynamo/client.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/dynamo/client.go
@@ -3,7 +3,6 @@ package dynamo
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
@@ -11,26 +10,19 @@ import (
 	appconfig "github.com/sayad-ika/craftsbite/internal/config"
 )
 
-var (
-	once   sync.Once
-	client *dynamodb.Client
-)
+func NewClient(cfg *appconfig.Config) (*dynamodb.Client, error) {
+	awscfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion(cfg.AWSRegion),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("dynamo: failed to load AWS config: %w", err)
+	}
 
-func GetClient(cfg *appconfig.Config) *dynamodb.Client {
-	once.Do(func() {
-		awscfg, err := awsconfig.LoadDefaultConfig(context.Background(),
-			awsconfig.WithRegion(cfg.AWSRegion),
-		)
-		if err != nil {
-			panic(fmt.Sprintf("dynamo: failed to load AWS config: %v", err))
+	client := dynamodb.NewFromConfig(awscfg, func(o *dynamodb.Options) {
+		if cfg.DynamoDBEndpoint != "" {
+			o.BaseEndpoint = aws.String(cfg.DynamoDBEndpoint)
 		}
-
-		client = dynamodb.NewFromConfig(awscfg, func(o *dynamodb.Options) {
-			if cfg.DynamoDBEndpoint != "" {
-				o.BaseEndpoint = aws.String(cfg.DynamoDBEndpoint)
-			}
-		})
 	})
 
-	return client
+	return client, nil
 }

--- a/02-task-2-craftsbite/craftsbite_backend/internal/dynamo/client_test.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/dynamo/client_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sayad-ika/craftsbite/internal/dynamo"
 )
 
-func TestGetClient_WithLocalEndpoint(t *testing.T) {
+func TestNewClient_WithLocalEndpoint(t *testing.T) {
 	cfg := &config.Config{
 		AWSRegion:        "ap-southeast-1",
 		DynamoDBEndpoint: "http://localhost:8000",
@@ -15,13 +15,16 @@ func TestGetClient_WithLocalEndpoint(t *testing.T) {
 		DiscordPublicKey: "aabbccdd",
 	}
 
-	c := dynamo.GetClient(cfg)
+	c, err := dynamo.NewClient(cfg)
+	if err != nil {
+		t.Fatalf("NewClient() returned unexpected error: %v", err)
+	}
 	if c == nil {
-		t.Fatal("GetClient() returned nil; expected a valid *dynamodb.Client")
+		t.Fatal("NewClient() returned nil; expected a valid *dynamodb.Client")
 	}
 }
 
-func TestGetClient_WithoutLocalEndpoint(t *testing.T) {
+func TestNewClient_WithoutLocalEndpoint(t *testing.T) {
 	cfg := &config.Config{
 		AWSRegion:        "ap-southeast-1",
 		DynamoDBEndpoint: "",
@@ -29,8 +32,11 @@ func TestGetClient_WithoutLocalEndpoint(t *testing.T) {
 		DiscordPublicKey: "aabbccdd",
 	}
 
-	c := dynamo.GetClient(cfg)
+	c, err := dynamo.NewClient(cfg)
+	if err != nil {
+		t.Fatalf("NewClient() returned unexpected error: %v", err)
+	}
 	if c == nil {
-		t.Fatal("GetClient() returned nil without DynamoDBEndpoint set")
+		t.Fatal("NewClient() returned nil without DynamoDBEndpoint set")
 	}
 }

--- a/02-task-2-craftsbite/craftsbite_backend/internal/gchat/adapter.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/gchat/adapter.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/sayad-ika/craftsbite/internal/payload"
+	"github.com/sayad-ika/craftsbite/internal/repository"
 )
 
 var gchatCommandNames = map[int64]string{
@@ -71,15 +72,6 @@ func ToCommandEvent(evt Event, internalUserID, role string) (payload.CommandEven
 	}, nil
 }
 
-var validMealTypes = map[string]bool{
-	"lunch":           true,
-	"snacks":          true,
-	"event_dinner":    true,
-	"optional_dinner": true,
-	"iftar":           true,
-	"all":             true,
-}
-
 func parseMealArgs(raw string) (map[string]interface{}, error) {
 	tokens := strings.Fields(raw)
 	if len(tokens) == 0 {
@@ -95,8 +87,8 @@ func parseMealArgs(raw string) (map[string]interface{}, error) {
 	if len(tokens) > 1 {
 		mealType = strings.ToLower(tokens[1])
 	}
-	if !validMealTypes[mealType] {
-		return nil, fmt.Errorf("Invalid meal_type. Allowed: lunch, snacks, event_dinner, optional_dinner, all")
+	if !repository.IsValidMealOrAll(mealType) {
+		return nil, fmt.Errorf("Invalid meal_type. Allowed: lunch, snacks, iftar, event_dinner, optional_dinner, all")
 	}
 
 	dateStr := ""
@@ -152,6 +144,9 @@ func parseHeadcountArgs(raw string) (map[string]interface{}, error) {
 	dateStr := ""
 	if len(tokens) > 0 {
 		dateStr = tokens[0]
+		if dateStr != "today" && dateStr != "tomorrow" && !strings.HasPrefix(dateStr, "+") && !strings.ContainsAny(dateStr, "0123456789") {
+			dateStr = ""
+		}
 	}
 
 	// Pass raw date string to Lambda - let it handle parsing with proper timezone

--- a/02-task-2-craftsbite/craftsbite_backend/internal/repository/constants.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/repository/constants.go
@@ -65,3 +65,7 @@ func IsValidMealType(mealType string) bool {
 	}
 	return false
 }
+
+func IsValidMealOrAll(mealType string) bool {
+	return mealType == "all" || IsValidMealType(mealType)
+}

--- a/02-task-2-craftsbite/craftsbite_backend/internal/repository/day.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/repository/day.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -11,8 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
-
-
 
 func GetDay(ctx context.Context, client *dynamodb.Client, table, date string) (*DaySchedule, error) {
 	out, err := client.GetItem(ctx, &dynamodb.GetItemInput{
@@ -87,7 +86,10 @@ func UpsertDaySchedule(ctx context.Context, client *dynamodb.Client, table strin
 	}
 
 	// Check if schedule already exists to preserve creation metadata
-	existing, _ := GetDay(ctx, client, table, schedule.Date)
+	existing, err := GetDay(ctx, client, table, schedule.Date)
+	if err != nil {
+		return fmt.Errorf("repository: UpsertDaySchedule get existing: %w", err)
+	}
 
 	createdBy := schedule.CreatedBy
 	createdAt := now
@@ -127,11 +129,17 @@ func UpsertDaySchedule(ctx context.Context, client *dynamodb.Client, table strin
 	oldValueJSON := ""
 	if existing != nil {
 		action = "UPDATE"
-		oldBytes, _ := json.Marshal(existing)
+		oldBytes, marshalErr := json.Marshal(existing)
+		if marshalErr != nil {
+			return fmt.Errorf("repository: UpsertDaySchedule marshal old value: %w", marshalErr)
+		}
 		oldValueJSON = string(oldBytes)
 	}
 
-	newBytes, _ := json.Marshal(schedule)
+	newBytes, marshalErr := json.Marshal(schedule)
+	if marshalErr != nil {
+		return fmt.Errorf("repository: UpsertDaySchedule marshal new value: %w", marshalErr)
+	}
 	newValueJSON := string(newBytes)
 
 	auditEntry := AuditEntry{
@@ -146,7 +154,9 @@ func UpsertDaySchedule(ctx context.Context, client *dynamodb.Client, table strin
 	}
 
 	// Best effort - don't fail the operation if audit write fails
-	_ = WriteAuditEntry(ctx, client, table, auditEntry)
+	if auditErr := WriteAuditEntry(ctx, client, table, auditEntry); auditErr != nil {
+		log.Printf("WARN: failed to write audit entry for DAY_SCHEDULE %s: %v", schedule.Date, auditErr)
+	}
 
 	// Also update the MEALS record for quick lookup
 	return upsertDayMeals(ctx, client, table, schedule.Date, schedule.AvailableMeals)

--- a/02-task-2-craftsbite/craftsbite_backend/internal/services/cutoff.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/services/cutoff.go
@@ -2,61 +2,30 @@ package services
 
 import (
 	"fmt"
-	"os"
 	"time"
 )
 
 const (
 	defaultCutoffTime = "21:00"
 	defaultTimezone   = "Asia/Dhaka"
-
-	maxDaysAhead = 7
+	defaultMaxDays    = 7
 )
 
-func IsBeforeCutoff(targetDate string) (bool, error) {
-	return isBeforeCutoffAt(targetDate, time.Now())
+type CutoffConfig struct {
+	CutoffTime   string
+	Timezone     string
+	MaxDaysAhead int
 }
 
-func isBeforeCutoffAt(targetDate string, now time.Time) (bool, error) {
-	loc, err := loadLocation()
-	if err != nil {
-		return false, err
-	}
-
-	cutoffStr := os.Getenv("CUTOFF_TIME")
-	if cutoffStr == "" {
-		cutoffStr = defaultCutoffTime
-	}
-
-	var cutoffHour, cutoffMin int
-	if _, err := fmt.Sscanf(cutoffStr, "%d:%d", &cutoffHour, &cutoffMin); err != nil {
-		return false, fmt.Errorf("cutoff: invalid CUTOFF_TIME %q: %w", cutoffStr, err)
-	}
-
-	target, err := time.ParseInLocation("2006-01-02", targetDate, loc)
-	if err != nil {
-		return false, fmt.Errorf("cutoff: invalid targetDate %q: %w", targetDate, err)
-	}
-
-	nowLocal := now.In(loc)
-	todayLocal := time.Date(nowLocal.Year(), nowLocal.Month(), nowLocal.Day(), 0, 0, 0, 0, loc)
-
-	if !todayLocal.Before(target) {
-		return false, nil
-	}
-
-	daysAhead := int(target.Sub(todayLocal).Hours() / 24)
-	if daysAhead > maxDaysAhead {
-		return false, nil
-	}
-
-	dayBeforeTarget := target.AddDate(0, 0, -1)
-	cutoff := time.Date(dayBeforeTarget.Year(), dayBeforeTarget.Month(), dayBeforeTarget.Day(), cutoffHour, cutoffMin, 0, 0, loc)
-	return nowLocal.Before(cutoff), nil
+type CutoffChecker struct {
+	loc        *time.Location
+	cutoffHour int
+	cutoffMin  int
+	maxDays    int
 }
 
-func loadLocation() (*time.Location, error) {
-	tz := os.Getenv("TIMEZONE")
+func NewCutoffChecker(cfg CutoffConfig) (*CutoffChecker, error) {
+	tz := cfg.Timezone
 	if tz == "" {
 		tz = defaultTimezone
 	}
@@ -64,5 +33,66 @@ func loadLocation() (*time.Location, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cutoff: invalid TIMEZONE %q: %w", tz, err)
 	}
-	return loc, nil
+
+	cutoffStr := cfg.CutoffTime
+	if cutoffStr == "" {
+		cutoffStr = defaultCutoffTime
+	}
+
+	var h, m int
+	if _, err := fmt.Sscanf(cutoffStr, "%d:%d", &h, &m); err != nil {
+		return nil, fmt.Errorf("cutoff: invalid CUTOFF_TIME %q: %w", cutoffStr, err)
+	}
+
+	maxDays := cfg.MaxDaysAhead
+	if maxDays == 0 {
+		maxDays = defaultMaxDays
+	}
+
+	return &CutoffChecker{loc: loc, cutoffHour: h, cutoffMin: m, maxDays: maxDays}, nil
+}
+
+func (c *CutoffChecker) IsBeforeCutoff(targetDate string) (bool, error) {
+	return c.isBeforeCutoffAt(targetDate, time.Now())
+}
+
+func (c *CutoffChecker) isBeforeCutoffAt(targetDate string, now time.Time) (bool, error) {
+	if c == nil || c.loc == nil {
+		return false, fmt.Errorf("cutoff checker is not initialized")
+	}
+
+	nowLocal := now.In(c.loc)
+	todayLocal := time.Date(nowLocal.Year(), nowLocal.Month(), nowLocal.Day(), 0, 0, 0, 0, c.loc)
+
+	target, err := time.ParseInLocation("2006-01-02", targetDate, c.loc)
+	if err != nil {
+		return false, fmt.Errorf("cutoff: invalid targetDate %q: %w", targetDate, err)
+	}
+
+	if !todayLocal.Before(target) {
+		return false, nil
+	}
+
+	daysAhead := int(target.Sub(todayLocal).Hours() / 24)
+	if daysAhead > c.maxDays {
+		return false, nil
+	}
+
+	dayBeforeTarget := target.AddDate(0, 0, -1)
+	cutoff := time.Date(dayBeforeTarget.Year(), dayBeforeTarget.Month(), dayBeforeTarget.Day(), c.cutoffHour, c.cutoffMin, 0, 0, c.loc)
+	return nowLocal.Before(cutoff), nil
+}
+
+func (c *CutoffChecker) Location() *time.Location {
+	if c == nil {
+		return nil
+	}
+	return c.loc
+}
+
+func (c *CutoffChecker) MaxDaysAhead() int {
+	if c == nil {
+		return 0
+	}
+	return c.maxDays
 }

--- a/02-task-2-craftsbite/craftsbite_backend/internal/services/cutoff_test.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/services/cutoff_test.go
@@ -15,16 +15,14 @@ func dhakaLoc(t *testing.T) *time.Location {
 }
 
 func TestScenario_RequestMar10_TargetMar11(t *testing.T) {
-	t.Setenv("CUTOFF_TIME", "21:00")
-	t.Setenv("TIMEZONE", "Asia/Dhaka")
-
+	checker := mustCutoffChecker(t)
 	loc := dhakaLoc(t)
 
 	const target = "2026-03-11"
 
 	t.Run("before cutoff (18:00) — should be allowed", func(t *testing.T) {
 		now := time.Date(2026, 3, 10, 18, 0, 0, 0, loc)
-		got, err := isBeforeCutoffAt(target, now)
+		got, err := checker.isBeforeCutoffAt(target, now)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -35,7 +33,7 @@ func TestScenario_RequestMar10_TargetMar11(t *testing.T) {
 
 	t.Run("after cutoff (22:00) — should be denied", func(t *testing.T) {
 		now := time.Date(2026, 3, 10, 22, 0, 0, 0, loc)
-		got, err := isBeforeCutoffAt(target, now)
+		got, err := checker.isBeforeCutoffAt(target, now)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -46,15 +44,13 @@ func TestScenario_RequestMar10_TargetMar11(t *testing.T) {
 }
 
 func TestScenario_RequestMar10_2300_TargetMar10(t *testing.T) {
-	t.Setenv("CUTOFF_TIME", "21:00")
-	t.Setenv("TIMEZONE", "Asia/Dhaka")
-
+	checker := mustCutoffChecker(t)
 	loc := dhakaLoc(t)
 
 	now := time.Date(2026, 3, 10, 23, 0, 0, 0, loc)
 	const target = "2026-03-10"
 
-	got, err := isBeforeCutoffAt(target, now)
+	got, err := checker.isBeforeCutoffAt(target, now)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -64,9 +60,7 @@ func TestScenario_RequestMar10_2300_TargetMar10(t *testing.T) {
 }
 
 func TestMultiDayLookahead(t *testing.T) {
-	t.Setenv("CUTOFF_TIME", "21:00")
-	t.Setenv("TIMEZONE", "Asia/Dhaka")
-
+	checker := mustCutoffChecker(t)
 	loc := dhakaLoc(t)
 
 	now := time.Date(2026, 3, 10, 10, 0, 0, 0, loc)
@@ -86,12 +80,12 @@ func TestMultiDayLookahead(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := isBeforeCutoffAt(tc.target, now)
+			got, err := checker.isBeforeCutoffAt(tc.target, now)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			if got != tc.wantOk {
-				t.Errorf("isBeforeCutoffAt(%q, 2026-03-10 10:00) = %v; want %v",
+				t.Errorf("CutoffChecker.isBeforeCutoffAt(%q, 2026-03-10 10:00) = %v; want %v",
 					tc.target, got, tc.wantOk)
 			}
 		})
@@ -99,9 +93,7 @@ func TestMultiDayLookahead(t *testing.T) {
 }
 
 func TestPostCutoff_StillAllowsFurtherDays(t *testing.T) {
-	t.Setenv("CUTOFF_TIME", "21:00")
-	t.Setenv("TIMEZONE", "Asia/Dhaka")
-
+	checker := mustCutoffChecker(t)
 	loc := dhakaLoc(t)
 
 	now := time.Date(2026, 3, 10, 23, 45, 0, 0, loc)
@@ -120,12 +112,12 @@ func TestPostCutoff_StillAllowsFurtherDays(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := isBeforeCutoffAt(tc.target, now)
+			got, err := checker.isBeforeCutoffAt(tc.target, now)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			if got != tc.wantOk {
-				t.Errorf("isBeforeCutoffAt(%q, 2026-03-10 23:45) = %v; want %v",
+				t.Errorf("CutoffChecker.isBeforeCutoffAt(%q, 2026-03-10 23:45) = %v; want %v",
 					tc.target, got, tc.wantOk)
 			}
 		})
@@ -133,10 +125,17 @@ func TestPostCutoff_StillAllowsFurtherDays(t *testing.T) {
 }
 
 func TestIsBeforeCutoff_InvalidTimezone(t *testing.T) {
-	t.Setenv("TIMEZONE", "NotAReal/Timezone")
-
-	_, err := isBeforeCutoffAt("2026-03-10", time.Now())
+	_, err := NewCutoffChecker(CutoffConfig{Timezone: "NotAReal/Timezone"})
 	if err == nil {
 		t.Fatal("expected error for invalid timezone; got nil")
 	}
+}
+
+func mustCutoffChecker(t *testing.T) *CutoffChecker {
+	t.Helper()
+	checker, err := NewCutoffChecker(CutoffConfig{CutoffTime: "21:00", Timezone: "Asia/Dhaka"})
+	if err != nil {
+		t.Fatalf("NewCutoffChecker() returned unexpected error: %v", err)
+	}
+	return checker
 }

--- a/02-task-2-craftsbite/craftsbite_backend/internal/services/participation.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/services/participation.go
@@ -78,11 +78,12 @@ func GetUserMealStatus(ctx context.Context, client *dynamodb.Client, table, user
 	return statuses, nil
 }
 
-func UpdateParticipation(ctx context.Context, client *dynamodb.Client, table, userID, date, mealType string, isParticipating bool) ([]ResolvedStatus, error) {
-	loc, err := loadLocation()
-	if err != nil {
-		return nil, fmt.Errorf("participation: load timezone: %w", err)
+func UpdateParticipation(ctx context.Context, client *dynamodb.Client, table, userID, date, mealType string, isParticipating bool, cutoff *CutoffChecker) ([]ResolvedStatus, error) {
+	if cutoff == nil {
+		return nil, fmt.Errorf("participation: cutoff checker is required")
 	}
+
+	loc := cutoff.Location()
 	nowLocal := time.Now().In(loc)
 	today := nowLocal.Format("2006-01-02")
 
@@ -96,11 +97,11 @@ func UpdateParticipation(ctx context.Context, client *dynamodb.Client, table, us
 			return nil, fmt.Errorf("participation: invalid date %q: %w", date, parseErr)
 		}
 		todayMidnight := time.Date(nowLocal.Year(), nowLocal.Month(), nowLocal.Day(), 0, 0, 0, 0, loc)
-		if int(target.Sub(todayMidnight).Hours()/24) > maxDaysAhead {
+		if int(target.Sub(todayMidnight).Hours()/24) > cutoff.MaxDaysAhead() {
 			return nil, ErrTooFarAhead
 		}
 
-		ok, err := IsBeforeCutoff(date)
+		ok, err := cutoff.IsBeforeCutoff(date)
 		if err != nil {
 			return nil, fmt.Errorf("participation: cutoff check: %w", err)
 		}

--- a/02-task-2-craftsbite/craftsbite_backend/internal/services/work_location.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/services/work_location.go
@@ -35,11 +35,12 @@ func notSetLocation(userID, date string) *repository.WorkLocation {
 	}
 }
 
-func SetLocation(ctx context.Context, client *dynamodb.Client, table, userID, date, location string) (*repository.WorkLocation, error) {
-	loc, err := loadLocation()
-	if err != nil {
-		return nil, fmt.Errorf("location: load timezone: %w", err)
+func SetLocation(ctx context.Context, client *dynamodb.Client, table, userID, date, location string, cutoff *CutoffChecker) (*repository.WorkLocation, error) {
+	if cutoff == nil {
+		return nil, fmt.Errorf("location: cutoff checker is required")
 	}
+
+	loc := cutoff.Location()
 	nowLocal := time.Now().In(loc)
 	today := nowLocal.Format("2006-01-02")
 
@@ -52,11 +53,11 @@ func SetLocation(ctx context.Context, client *dynamodb.Client, table, userID, da
 			return nil, fmt.Errorf("location: invalid date %q: %w", date, parseErr)
 		}
 		todayMidnight := time.Date(nowLocal.Year(), nowLocal.Month(), nowLocal.Day(), 0, 0, 0, 0, loc)
-		if int(target.Sub(todayMidnight).Hours()/24) > maxDaysAhead {
+		if int(target.Sub(todayMidnight).Hours()/24) > cutoff.MaxDaysAhead() {
 			return nil, ErrLocationTooFarAhead
 		}
 
-		ok, err := IsBeforeCutoff(date)
+		ok, err := cutoff.IsBeforeCutoff(date)
 		if err != nil {
 			return nil, fmt.Errorf("location: cutoff check: %w", err)
 		}

--- a/02-task-2-craftsbite/craftsbite_backend/internal/services/work_location_test.go
+++ b/02-task-2-craftsbite/craftsbite_backend/internal/services/work_location_test.go
@@ -28,9 +28,7 @@ func TestGetLocationNotSetDefault(t *testing.T) {
 }
 
 func TestLocationDateGuards(t *testing.T) {
-	t.Setenv("CUTOFF_TIME", "21:00")
-	t.Setenv("TIMEZONE", "Asia/Dhaka")
-
+	checker := mustCutoffChecker(t)
 	loc := dhakaLoc(t)
 
 	tests := []struct {
@@ -88,10 +86,10 @@ func TestLocationDateGuards(t *testing.T) {
 			default:
 				target, _ := time.ParseInLocation("2006-01-02", tc.date, loc)
 				todayMidnight := time.Date(tc.now.Year(), tc.now.Month(), tc.now.Day(), 0, 0, 0, 0, loc)
-				if int(target.Sub(todayMidnight).Hours()/24) > maxDaysAhead {
+				if int(target.Sub(todayMidnight).Hours()/24) > checker.MaxDaysAhead() {
 					got = "tooFar"
 				} else {
-					ok, err := isBeforeCutoffAt(tc.date, tc.now)
+					ok, err := checker.isBeforeCutoffAt(tc.date, tc.now)
 					if err != nil {
 						t.Fatalf("unexpected error: %v", err)
 					}


### PR DESCRIPTION
Closes #65 

## Dependencies

#97 

## What does this PR do?

Removes global mutable state and duplicated code across all 6 Lambda handlers —
no architecture or functionality changes. Every `sync.Once` singleton and runtime
`os.Getenv` call is replaced with explicit constructor injection, making all
handlers testable without environment manipulation and all initialization errors
handleable without panics.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation

## What was changed

**`internal/cmdutil/cmdutil.go` (new)**
- Extracts 4 functions duplicated across `ops`, `self`, and `management`:
  `OptString`, `DisplayMealName`, `SendReply`, `SendGChatCard`
- `SendReply` replaces 3 near-identical reply functions (`sendOpsReply`,
  `sendSelfReply`, `sendMgmtReply`) — new version correctly checks the error
  from `gchat.SimpleTextCard` which was previously silently ignored with `_`

**`internal/dynamo/client.go`**
- `GetClient()` singleton → `NewClient(cfg) (*Client, error)` constructor
- Removes `sync.Once`, package-level `var client`, and `panic` on error
- Callers now handle the error in `main()` with `log.Fatalf`

**`internal/dateutil/dateutil.go` + `range.go`**
- Package-level functions reading `os.Getenv("TIMEZONE")` on every call →
  `DateParser` struct initialized once via `NewDateParser(timezone string)`
- Added internal `*At(..., now time.Time)` variants for deterministic testing
  without real `time.Now()` — all tests updated with fixed timestamps

**`internal/services/cutoff.go`**
- Package-level functions reading `os.Getenv("CUTOFF_TIME")` and
  `os.Getenv("TIMEZONE")` → `CutoffChecker` struct via
  `NewCutoffChecker(CutoffConfig)` — config resolved once at construction
- `maxDaysAhead` moved from hardcoded constant to configurable `CutoffConfig` field
- `Location()` and `MaxDaysAhead()` accessors added for dependent services

**`internal/services/participation.go` + `work_location.go`**
- Both gain an explicit `cutoff *CutoffChecker` parameter replacing internal
  `loadLocation()` calls and direct `os.Getenv` reads

**`internal/config/config.go`**
- Added `Timezone` (default: `"Asia/Dhaka"`) and `CutoffTime` (default: `"21:00"`)
  fields — centralizes what was previously scattered `os.Getenv` calls across
  `cutoff.go`, `participation.go`, `work_location.go`, and `dateutil.go`

**`internal/repository/day.go`**
- `UpsertDaySchedule` previously ignored errors from `GetDay`, `json.Marshal`,
  and `WriteAuditEntry` with `_` — now properly propagates the first two and
  logs a warning for audit entry failure (intentionally best-effort)

**`internal/repository/constants.go`**
- Added `IsValidMealOrAll` — replaces duplicate `validMealOptions` map in
  `cmd/self/main.go` and `validMealTypes` map in `gchat/adapter.go`

**All 6 `cmd/*/main.go` handlers**
- `sync.Once` + global `var cfg` removed from all handlers
- `main()` now explicitly initializes `cfg`, `client`, `dateParser`, and
  `cutoff` (where applicable), checks each error, and closes over them in a
  `lambda.Start` wrapper
- `cmd/router/main.go`: local `CommandPayload` duplicate type removed —
  replaced with canonical `payload.CommandEvent`
- `cmd/scheduled-headcount/main.go`: added `sync.Mutex` around goroutine
  error writes to fix a data race on `discordErr`/`gchatErr`

**`gchat/adapter.go`**
- `validMealTypes` local map → `repository.IsValidMealOrAll`
- Added date validation heuristic in `parseHeadcountArgs` to prevent non-date
  tokens from being passed as dates
- Error message corrected to include `iftar` in the allowed meal types list

## Changelog

None: not user visible

## How to Test

1. `go build ./...` — must succeed with no errors
2. `go test ./...` — all tests must pass
3. `go vet ./...` — must report no issues
4. Manually invoke one Lambda end-to-end (e.g. `/status` on Discord or Google
   Chat) to confirm handler wiring is correct

## How QA Should Test

No functional change — all existing slash command workflows should behave
identically. Run the full command matrix (one command per role) on both Discord
and Google Chat and verify responses are unchanged.

## Rollback Plan

Revert this PR. No data or infrastructure changes were made — rollback is safe
at any time.

## Checklist

- [x] My code follows the project style guidelines
- [x] Code passes linting and type checks
- [x] All tests pass
- [x] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)

## Note for Reviewer

Three specific areas worth close attention:

1. **`cmdutil.SendReply`** — the new unified version checks the error from
   `gchat.SimpleTextCard` where the 3 old functions ignored it with `_`. Verify
   callers handle this new error path correctly.

2. **`cmd/router/main.go`** — `CommandPayload` replaced with `payload.CommandEvent`.
   Verify all JSON field tags are identical to the old struct — a mismatch here
   would silently drop fields from the worker payload.

3. **`repository/day.go`** — `UpsertDaySchedule` now surfaces errors that were
   previously swallowed. Verify this doesn't cause unexpected failures in the
   `/schedule-day` command for edge cases that previously succeeded silently.